### PR TITLE
Feature/Add Terms & Educational Disclaimer page

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -331,6 +331,11 @@ def gallery():
     return render_template("gallery.html", images=images)
 
 
+@main_bp.route("/terms")
+def terms():
+    return render_template("terms.html")
+
+
 @main_bp.route("/api/generate", methods=["POST"])
 @login_required
 def generate():

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -335,6 +335,7 @@ def gallery():
 def terms():
     return render_template("terms.html")
 
+
 @main_bp.route("/privacy")
 def privacy():
     return render_template("privacy.html")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -105,7 +105,7 @@
                     <div class="col-md-4 text-center text-md-end">
                         <div class="d-flex justify-content-center justify-content-md-end gap-4">
                             <a href="#" class="text-secondary text-decoration-none small fw-semibold">Privacy</a>
-                            <a href="#" class="text-secondary text-decoration-none small fw-semibold">Terms</a>
+                            <a href="{{ url_for('main.terms') }}" class="text-secondary text-decoration-none small fw-semibold">Terms</a>
                             <a href="#" class="text-secondary text-decoration-none small fw-semibold">Support</a>
                         </div>
                     </div>

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -1,0 +1,61 @@
+{% extends 'base.html' %}
+
+{% block title %}Terms & Educational Disclaimer - TrueHair AI{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-7">
+            <h1 class="fw-bold display-5 text-white mb-2">Terms &amp; Educational Disclaimer</h1>
+            <p class="text-secondary mb-5">Last updated March 14, 2026</p>
+
+            <div class="card bg-card border border-secondary border-opacity-25 rounded-4 overflow-hidden">
+
+                <div class="p-4 p-md-5">
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-circle d-flex align-items-center justify-content-center flex-shrink-0"
+                            style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
+                            <i class="bi bi-mortarboard text-yellow"></i>
+                        </div>
+                        <h5 class="fw-bold text-white mb-0">Educational Prototype Disclaimer</h5>
+                    </div>
+                    <p class="text-secondary mb-0" style="line-height:1.75;">
+                        TrueHair.ai is an experimental prototype built as part of a university software engineering course project.
+                    </p>
+                </div>
+
+                <hr class="border-secondary border-opacity-25 m-0">
+
+                <div class="p-4 p-md-5">
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-circle d-flex align-items-center justify-content-center flex-shrink-0"
+                            style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
+                            <i class="bi bi-shield-exclamation text-yellow"></i>
+                        </div>
+                        <h5 class="fw-bold text-white mb-0">No Liability</h5>
+                    </div>
+                    <p class="text-secondary mb-0" style="line-height:1.75;">
+                        By utilizing this application, you understand and acknowledge that it is a work in progress and should not be relied upon for important decisions, critical tasks, or professional styling advice. The student developers of TrueHair.ai and Colby College assume no liability for any loss, harm, or damages resulting from the use, inability to use, or reliance on this prototype.
+                    </p>
+                </div>
+
+                <hr class="border-secondary border-opacity-25 m-0">
+
+                <div class="p-4 p-md-5">
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-circle d-flex align-items-center justify-content-center flex-shrink-0"
+                            style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
+                            <i class="bi bi-clock-history text-yellow"></i>
+                        </div>
+                        <h5 class="fw-bold text-white mb-0">Service Interruptions</h5>
+                    </div>
+                    <p class="text-secondary mb-0" style="line-height:1.75;">
+                        Because this is a testing environment, the application may experience downtime, data resets, or unexpected behavior. We do not guarantee continuous uptime or data preservation.
+                    </p>
+                </div>
+
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -10,6 +10,17 @@ def test_index(client):
     """Test the index page."""
     response = client.get("/")
     assert response.status_code == 200
+    assert b'href="/terms"' in response.data
+
+
+def test_terms_page_public(client):
+    """Terms page is public and renders required disclaimer content."""
+    response = client.get("/terms")
+    assert response.status_code == 200
+    assert b"Terms &amp; Educational Disclaimer" in response.data
+    assert b"Educational Prototype Disclaimer" in response.data
+    assert b"No Liability" in response.data
+    assert b"Service Interruptions" in response.data
 
 
 def test_dashboard_redirect_unauthenticated(client):


### PR DESCRIPTION
## Description
This PR adds a dedicated **Terms & Educational Disclaimer** page to the application.  
The page provides a liability waiver and clarifies that TrueHair.ai is an experimental educational prototype built for a university software engineering course.

The new page is accessible at `/terms` and is linked from the footer so users can easily access the disclaimer.

## Related Issues
Closes #10 

## Changes Made
- Added a new `/terms` route in `main.py`
- Created a `terms.html` template with the required disclaimer content
- Implemented the headline **"Terms & Educational Disclaimer"** and the required body sections:
  - Educational Prototype Disclaimer
  - No Liability
  - Service Interruptions
- Ensured the page styling matches the rest of the application UI
- Linked the **"Terms"** text in the footer to the new `/terms` page
- Added automated tests to verify the terms page renders correctly

## Testing & Verification
The following tests were added and executed to verify functionality:

1. Confirmed the `/terms` route loads successfully (HTTP 200).
2. Verified that the page contains the required disclaimer text sections.
3. Ensured the footer **Terms** link points to the `/terms` page.
4. Ran the existing test suite to confirm no regressions were introduced.

All tests pass successfully.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
