### PR TITLE
 Add drag-and-drop functionality for image uploads to the style …

### DIFF
--- a/app/templates/style_studio.html
+++ b/app/templates/style_studio.html
@@ -148,6 +148,38 @@
             }
         });
 
+        // Handle Drag & Drop
+        uploadContainer.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            uploadContainer.classList.add('drag-active');
+        });
+
+        uploadContainer.addEventListener('dragleave', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            // Only remove highlight if leaving the container itself (not a child element)
+            if (!uploadContainer.contains(e.relatedTarget)) {
+                uploadContainer.classList.remove('drag-active');
+            }
+        });
+
+        uploadContainer.addEventListener('drop', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            uploadContainer.classList.remove('drag-active');
+
+            const files = e.dataTransfer.files;
+            if (files && files.length > 0) {
+                const file = files[0];
+                if (!file.type.startsWith('image/')) {
+                    showFlashMessage('Please drop an image file (PNG, JPG, etc.)');
+                    return;
+                }
+                uploadFile(file);
+            }
+        });
+
         function uploadFile(file) {
             const formData = new FormData();
             formData.append('file', file);
@@ -277,6 +309,13 @@
     .border-yellow {
         border-color: var(--th-yellow) !important;
         border-width: 2px !important;
+    }
+
+    .drag-active {
+        border-color: var(--th-yellow) !important;
+        background-color: rgba(255, 214, 0, 0.07) !important;
+        box-shadow: 0 0 0 3px rgba(255, 214, 0, 0.25);
+        transition: all 0.15s ease;
     }
 </style>
 {% endblock %}


### PR DESCRIPTION
## Description
This PR adds drag and drop functionality for image uploads to style

## Related Issues
Fixes #2 

## Changes Made
-  Added dragover event listener to the upload zone to prevent default browser behavior and apply visual highlight during drag
- Added dragleave event listener to remove the drag highlight when the cursor exits the upload zone 
-  Added drop event listener to extract the dropped file, validate it is an image type, and pass it to the existing 
uploadFile() function
- Added drag-active CSS class with a yellow border glow and subtle background tint for visual drag feedback

## Testing & Verification
Navigate to the Style Studio page
- Open your file manager/Finder and locate an image file (PNG or JPG)
- Drag the image over the upload zone 
-  confirm the border turns yellow with a glow effect


## Checklist
- [X] I have performed a self-review of my own code
- [] I have added tests that prove my fix is effective or that my feature works
- [X] My code follows the style guidelines of this project
- [X] My changes generate no new warnings