### PR TITLE
Feature: Implement Cloud Storage Integration.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@ FLASK_SECRET_KEY=your-super-secret-key-here
 GOOGLE_CLIENT_ID=your-google-oauth-client-id
 GOOGLE_CLIENT_SECRET=your-google-oauth-client-secret
 GEMINI_API_KEY=your-gemini-api-key
+R2_ACCOUNT_ID=your-r2-account-id
+R2_ACCESS_KEY_ID=your-r2-access-key-id
+R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
+R2_BUCKET_NAME=your-r2-bucket-name

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,3 +1,4 @@
+import io
 import os
 import uuid
 from datetime import datetime, timedelta
@@ -21,6 +22,7 @@ from sqlalchemy import func
 from werkzeug.utils import secure_filename
 
 from app.models import GeneratedImage, Hairstyle, Stylist, User, UserImage, Visit, db
+from app.services import r2 as r2_service
 
 main_bp = Blueprint("main", __name__)
 
@@ -86,36 +88,47 @@ def style_studio():
     return render_template("style_studio.html", hairstyles=hairstyles)
 
 
-@main_bp.route("/upload", methods=["POST"])
+@main_bp.route("/api/upload/presign", methods=["POST"])
 @login_required
-def upload_image():
-    if "file" not in request.files:
-        return jsonify({"error": "No file part"}), 400
-    file = request.files["file"]
-    if file.filename == "":
-        return jsonify({"error": "No selected file"}), 400
+def upload_presign():
+    """Return a presigned PUT URL so the client can upload directly to R2."""
+    data = request.get_json(silent=True) or {}
+    filename = data.get("filename", "photo.jpg")
+    content_type = data.get("content_type", "image/jpeg")
 
-    if file:
-        filename = secure_filename(f"{uuid.uuid4()}_{file.filename}")
-        static_folder = current_app.static_folder or ""
-        upload_dir = os.path.join(static_folder, "uploads")
-        os.makedirs(upload_dir, exist_ok=True)
-        upload_path = os.path.join(upload_dir, filename)
-        file.save(upload_path)
+    if content_type not in r2_service.ALLOWED_CONTENT_TYPES:
+        return jsonify({"error": f"Unsupported content type: {content_type}"}), 400
 
-        user_image = UserImage(
-            user_id=session["user_id"], image_url=f"uploads/{filename}"
-        )
-        db.session.add(user_image)
-        db.session.commit()
+    upload_key = r2_service.make_upload_key(filename)
+    put_url = r2_service.get_presigned_put_url(upload_key, content_type)
 
-        return jsonify(
-            {
-                "status": "success",
-                "image_url": f"/static/uploads/{filename}",
-                "image_id": user_image.id,
-            }
-        )
+    return jsonify({"put_url": put_url, "upload_key": upload_key})
+
+
+@main_bp.route("/api/upload/confirm", methods=["POST"])
+@login_required
+def upload_confirm():
+    """Confirm a client-side R2 upload and create the DB record."""
+    data = request.get_json(silent=True) or {}
+    upload_key = data.get("upload_key")
+
+    if not upload_key or not upload_key.startswith("uploads/"):
+        return jsonify({"error": "Invalid upload_key"}), 400
+
+    user_image = UserImage(
+        user_id=session["user_id"],
+        image_url=upload_key,
+    )
+    db.session.add(user_image)
+    db.session.commit()
+
+    return jsonify(
+        {
+            "status": "success",
+            "image_url": r2_service.get_display_url(upload_key),
+            "image_id": user_image.id,
+        }
+    )
 
 
 @main_bp.route("/stylists")
@@ -316,7 +329,11 @@ def result(image_id=None):
             .first()
         )
 
-    return render_template("result.html", latest_gen=gen_img)
+    image_display_url = r2_service.get_display_url(gen_img.image_url) if gen_img else None
+
+    return render_template(
+        "result.html", latest_gen=gen_img, image_display_url=image_display_url
+    )
 
 
 @main_bp.route("/gallery")
@@ -328,7 +345,10 @@ def gallery():
         .order_by(GeneratedImage.created_at.desc())
         .all()
     )
-    return render_template("gallery.html", images=images)
+
+    display_urls = {img.id: r2_service.get_display_url(img.image_url) for img in images}
+
+    return render_template("gallery.html", images=images, display_urls=display_urls)
 
 
 @main_bp.route("/terms")
@@ -365,9 +385,8 @@ def generate():
         return jsonify({"error": "Internal server error. Please try again later."}), 500
 
     try:
-        static_folder = current_app.static_folder or ""
-        img_path = os.path.join(static_folder, user_image.image_url)
-        user_photo = Image.open(img_path)
+        photo_bytes = r2_service.download_bytes(user_image.image_url)
+        user_photo = Image.open(io.BytesIO(photo_bytes))
 
         prompt = (
             f"Edit this person's photo to give them a '{hairstyle.name}' hairstyle. "
@@ -386,19 +405,19 @@ def generate():
             ),
         )
 
-        result_filename = f"gen_{uuid.uuid4()}.png"
-        result_url = f"uploads/{result_filename}"
-        static_folder = current_app.static_folder or ""
-        result_path = os.path.join(static_folder, result_url)
-        os.makedirs(os.path.dirname(result_path), exist_ok=True)
-
+        image_part = None
         for part in response.parts:
             if part.inline_data is not None:
-                generated_image = part.as_image()
-                generated_image.save(result_path)
+                image_part = part
                 break
         else:
             raise Exception("No image returned by the model.")
+
+        result_key = r2_service.make_generated_key()
+        image_bytes = image_part.inline_data.data
+        mime_type = image_part.inline_data.mime_type or "image/png"
+        r2_service.upload_bytes(result_key, image_bytes, mime_type)
+        result_url = result_key
 
         gen_img = GeneratedImage(
             user_id=session["user_id"],
@@ -412,7 +431,7 @@ def generate():
         return jsonify(
             {
                 "status": "success",
-                "image_url": f"/static/{result_url}",
+                "image_url": r2_service.get_display_url(result_url),
                 "image_id": gen_img.id,
             }
         )

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,6 +1,4 @@
 import io
-import os
-import uuid
 from datetime import datetime, timedelta
 from functools import wraps
 
@@ -19,7 +17,6 @@ from google import genai
 from google.genai import types
 from PIL import Image
 from sqlalchemy import func
-from werkzeug.utils import secure_filename
 
 from app.models import GeneratedImage, Hairstyle, Stylist, User, UserImage, Visit, db
 from app.services import r2 as r2_service
@@ -329,7 +326,9 @@ def result(image_id=None):
             .first()
         )
 
-    image_display_url = r2_service.get_display_url(gen_img.image_url) if gen_img else None
+    image_display_url = (
+        r2_service.get_display_url(gen_img.image_url) if gen_img else None
+    )
 
     return render_template(
         "result.html", latest_gen=gen_img, image_display_url=image_display_url

--- a/app/services/r2.py
+++ b/app/services/r2.py
@@ -1,0 +1,88 @@
+import uuid
+
+import boto3
+from flask import current_app
+from werkzeug.utils import secure_filename
+
+ALLOWED_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
+
+
+def _get_s3_client():
+    """Return a boto3 S3 client configured for Cloudflare R2."""
+    account_id = current_app.config["R2_ACCOUNT_ID"]
+    return boto3.client(
+        "s3",
+        endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
+        aws_access_key_id=current_app.config["R2_ACCESS_KEY_ID"],
+        aws_secret_access_key=current_app.config["R2_SECRET_ACCESS_KEY"],
+        region_name="auto",
+    )
+
+
+def make_upload_key(filename):
+    """Generate a unique R2 object key for a user upload."""
+    safe = secure_filename(filename) if filename else "photo"
+    return f"uploads/{uuid.uuid4()}_{safe}"
+
+
+def make_generated_key():
+    """Generate a unique R2 object key for a generated image."""
+    return f"uploads/gen_{uuid.uuid4()}.png"
+
+
+def get_presigned_put_url(key, content_type="image/jpeg", expires_in=3600):
+    """Return a presigned PUT URL for the given object key."""
+    client = _get_s3_client()
+    return client.generate_presigned_url(
+        "put_object",
+        Params={
+            "Bucket": current_app.config["R2_BUCKET_NAME"],
+            "Key": key,
+            "ContentType": content_type,
+        },
+        ExpiresIn=expires_in,
+    )
+
+
+def get_presigned_get_url(key, expires_in=3600):
+    """Return a presigned GET URL for the given object key."""
+    client = _get_s3_client()
+    return client.generate_presigned_url(
+        "get_object",
+        Params={
+            "Bucket": current_app.config["R2_BUCKET_NAME"],
+            "Key": key,
+        },
+        ExpiresIn=expires_in,
+    )
+
+
+def upload_bytes(key, data, content_type="image/png"):
+    """Upload raw bytes to R2 under the given key."""
+    client = _get_s3_client()
+    client.put_object(
+        Bucket=current_app.config["R2_BUCKET_NAME"],
+        Key=key,
+        Body=data,
+        ContentType=content_type,
+    )
+
+
+def download_bytes(key):
+    """Download an object from R2 and return its bytes."""
+    client = _get_s3_client()
+    response = client.get_object(
+        Bucket=current_app.config["R2_BUCKET_NAME"],
+        Key=key,
+    )
+    return response["Body"].read()
+
+
+def get_display_url(image_url):
+    """Return a presigned GET URL for an image stored in R2.
+
+    Returns None if image_url is falsy (e.g. no image yet).
+    """
+    if not image_url:
+        return None
+    return get_presigned_get_url(image_url)

--- a/app/templates/gallery.html
+++ b/app/templates/gallery.html
@@ -17,7 +17,7 @@
         <div class="col-sm-6 col-md-4 col-lg-3">
             <div
                 class="card bg-card border border-secondary border-opacity-25 rounded-4 overflow-hidden h-100 shadow-sm">
-                <img src="{{ url_for('static', filename=img.image_url) }}" class="card-img-top w-100"
+                <img src="{{ display_urls[img.id] }}" class="card-img-top w-100"
                     style="aspect-ratio: 1/1; object-fit: cover;" alt="Generated Hairstyle">
                 <div class="card-body p-3 d-flex justify-content-between align-items-center">
                     <div>
@@ -32,7 +32,7 @@
                             style="width: 32px; height: 32px;" title="View Result">
                             <i class="bi bi-eye"></i>
                         </a>
-                        <a href="{{ url_for('static', filename=img.image_url) }}"
+                        <a href="{{ display_urls[img.id] }}"
                             download="truehair_{{ img.hairstyle.name | replace(' ', '_') }}_{{ img.id }}.png"
                             class="btn btn-outline-yellow btn-sm rounded-circle d-flex align-items-center justify-content-center"
                             style="width: 32px; height: 32px;" title="Download">

--- a/app/templates/result.html
+++ b/app/templates/result.html
@@ -27,8 +27,8 @@
             <!-- Image Card -->
             <div class="rounded-4 overflow-hidden border border-secondary border-opacity-25 shadow"
                 style="background-color: #1c1c1e;">
-                {% if latest_gen %}
-                <img src="{{ url_for('static', filename=latest_gen.image_url) }}" class="img-fluid w-100"
+                {% if latest_gen and image_display_url %}
+                <img src="{{ image_display_url }}" class="img-fluid w-100"
                     style="object-fit: cover; aspect-ratio: 16/10;" alt="Generated Profile">
                 {% else %}
                 <img src="{{ url_for('static', filename='images/classic-fade-result.png') }}" class="img-fluid w-100"
@@ -47,8 +47,8 @@
                     style="background-color: #2a2a2d;" onclick="window.location.href='{{ url_for('main.gallery') }}';">
                     <i class="bi bi-images text-secondary"></i> My Gallery
                 </button>
-                {% if latest_gen %}
-                <a href="{{ url_for('static', filename=latest_gen.image_url) }}"
+                {% if latest_gen and image_display_url %}
+                <a href="{{ image_display_url }}"
                     download="truehair_{{ latest_gen.hairstyle.name | replace(' ', '_') }}_{{ latest_gen.id }}.png"
                     class="btn btn-dark border border-secondary border-opacity-50 rounded-3 d-flex align-items-center justify-content-center px-4 py-3"
                     style="background-color: #2a2a2d;" title="Download Result">

--- a/app/templates/style_studio.html
+++ b/app/templates/style_studio.html
@@ -183,34 +183,48 @@
         });
 
         function uploadFile(file) {
-            const formData = new FormData();
-            formData.append('file', file);
-
             placeholder.classList.add('d-none');
             spinner.classList.remove('d-none');
 
-            fetch("{{ url_for('main.upload_image') }}", {
+            fetch("{{ url_for('main.upload_presign') }}", {
                 method: 'POST',
-                body: formData
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ filename: file.name, content_type: file.type || 'image/jpeg' })
             })
-                .then(response => response.json())
-                .then(data => {
-                    spinner.classList.add('d-none');
-                    if (data.status === 'success') {
-                        previewImg.src = data.image_url;
-                        uploadedImageId = data.image_id;
-                        previewContainer.classList.remove('d-none');
-                        checkEnableGenerate();
-                    } else {
-                        alert('Upload failed: ' + data.error);
-                        placeholder.classList.remove('d-none');
-                    }
-                })
-                .catch(err => {
-                    console.error(err);
-                    spinner.classList.add('d-none');
+            .then(r => r.json())
+            .then(presignData => {
+                if (presignData.error) throw presignData;
+                return fetch(presignData.put_url, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': file.type || 'image/jpeg' },
+                    body: file
+                }).then(() => presignData.upload_key);
+            })
+            .then(uploadKey => {
+                return fetch("{{ url_for('main.upload_confirm') }}", {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ upload_key: uploadKey })
+                }).then(r => r.json());
+            })
+            .then(data => {
+                spinner.classList.add('d-none');
+                if (data.status === 'success') {
+                    previewImg.src = data.image_url;
+                    uploadedImageId = data.image_id;
+                    previewContainer.classList.remove('d-none');
+                    checkEnableGenerate();
+                } else {
+                    showFlashMessage(data.error || 'Upload failed.');
                     placeholder.classList.remove('d-none');
-                });
+                }
+            })
+            .catch(err => {
+                console.error(err);
+                spinner.classList.add('d-none');
+                showFlashMessage(err.error || 'Upload failed. Please try again.');
+                placeholder.classList.remove('d-none');
+            });
         }
 
         removeBtn.addEventListener('click', () => {

--- a/config.py
+++ b/config.py
@@ -15,3 +15,8 @@ class Config:
     GOOGLE_CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET")
     SERVER_METADATA_URL = "https://accounts.google.com/.well-known/openid-configuration"
     GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
+
+    R2_ACCOUNT_ID = os.environ.get("R2_ACCOUNT_ID")
+    R2_ACCESS_KEY_ID = os.environ.get("R2_ACCESS_KEY_ID")
+    R2_SECRET_ACCESS_KEY = os.environ.get("R2_SECRET_ACCESS_KEY")
+    R2_BUCKET_NAME = os.environ.get("R2_BUCKET_NAME")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "psycopg2-binary>=2.9.10",
     "python-dotenv>=1.2.2",
     "requests>=2.32.5",
+    "boto3>=1.38.0",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,13 @@ class TestConfig(Config):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     WTF_CSRF_ENABLED = False
-    # Mocking environment variables for tests
     GOOGLE_CLIENT_ID = "test-id"
     GOOGLE_CLIENT_SECRET = "test-secret"
     GEMINI_API_KEY = "test-gemini-key"
-
+    R2_ACCOUNT_ID = "test-account-id"
+    R2_ACCESS_KEY_ID = "test-access-key"
+    R2_SECRET_ACCESS_KEY = "test-secret-key"
+    R2_BUCKET_NAME = "test-bucket"
 
 @pytest.fixture
 def app():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ class TestConfig(Config):
     R2_SECRET_ACCESS_KEY = "test-secret-key"
     R2_BUCKET_NAME = "test-bucket"
 
+
 @pytest.fixture
 def app():
     app = create_app(TestConfig)

--- a/tests/test_r2_service.py
+++ b/tests/test_r2_service.py
@@ -1,0 +1,136 @@
+"""Tests for the R2 cloud storage service module."""
+
+from unittest.mock import MagicMock, patch
+
+from app.services import r2 as r2_service
+
+
+def test_make_upload_key_format(app):
+    """Upload key has uploads/ prefix and sanitized filename."""
+    with app.app_context():
+        key = r2_service.make_upload_key("my photo.png")
+        assert key.startswith("uploads/")
+        assert "my_photo.png" in key
+
+
+def test_make_upload_key_default_when_empty(app):
+    """Upload key falls back to 'photo' when filename is empty."""
+    with app.app_context():
+        key = r2_service.make_upload_key("")
+        assert key.startswith("uploads/")
+        assert "photo" in key
+
+
+def test_make_generated_key_format(app):
+    """Generated key has uploads/gen_ prefix and .png extension."""
+    with app.app_context():
+        key = r2_service.make_generated_key()
+        assert key.startswith("uploads/gen_")
+        assert key.endswith(".png")
+
+
+def test_make_upload_key_unique(app):
+    """Two calls produce different keys."""
+    with app.app_context():
+        k1 = r2_service.make_upload_key("photo.jpg")
+        k2 = r2_service.make_upload_key("photo.jpg")
+        assert k1 != k2
+
+
+@patch("app.services.r2._get_s3_client")
+def test_get_presigned_put_url(mock_client_fn, app):
+    """get_presigned_put_url calls generate_presigned_url with put_object."""
+    mock_client = MagicMock()
+    mock_client.generate_presigned_url.return_value = "https://r2.example.com/put"
+    mock_client_fn.return_value = mock_client
+
+    with app.app_context():
+        url = r2_service.get_presigned_put_url("uploads/test.jpg", "image/jpeg")
+
+    assert url == "https://r2.example.com/put"
+    mock_client.generate_presigned_url.assert_called_once_with(
+        "put_object",
+        Params={
+            "Bucket": "test-bucket",
+            "Key": "uploads/test.jpg",
+            "ContentType": "image/jpeg",
+        },
+        ExpiresIn=3600,
+    )
+
+
+@patch("app.services.r2._get_s3_client")
+def test_get_presigned_get_url(mock_client_fn, app):
+    """get_presigned_get_url calls generate_presigned_url with get_object."""
+    mock_client = MagicMock()
+    mock_client.generate_presigned_url.return_value = "https://r2.example.com/get"
+    mock_client_fn.return_value = mock_client
+
+    with app.app_context():
+        url = r2_service.get_presigned_get_url("uploads/test.jpg")
+
+    assert url == "https://r2.example.com/get"
+    mock_client.generate_presigned_url.assert_called_once_with(
+        "get_object",
+        Params={
+            "Bucket": "test-bucket",
+            "Key": "uploads/test.jpg",
+        },
+        ExpiresIn=3600,
+    )
+
+
+@patch("app.services.r2._get_s3_client")
+def test_upload_bytes(mock_client_fn, app):
+    """upload_bytes calls put_object with correct params."""
+    mock_client = MagicMock()
+    mock_client_fn.return_value = mock_client
+
+    with app.app_context():
+        r2_service.upload_bytes("uploads/gen_abc.png", b"fake-image", "image/png")
+
+    mock_client.put_object.assert_called_once_with(
+        Bucket="test-bucket",
+        Key="uploads/gen_abc.png",
+        Body=b"fake-image",
+        ContentType="image/png",
+    )
+
+
+@patch("app.services.r2._get_s3_client")
+def test_download_bytes(mock_client_fn, app):
+    """download_bytes returns object body bytes."""
+    mock_body = MagicMock()
+    mock_body.read.return_value = b"image-data"
+    mock_client = MagicMock()
+    mock_client.get_object.return_value = {"Body": mock_body}
+    mock_client_fn.return_value = mock_client
+
+    with app.app_context():
+        data = r2_service.download_bytes("uploads/test.jpg")
+
+    assert data == b"image-data"
+    mock_client.get_object.assert_called_once_with(
+        Bucket="test-bucket",
+        Key="uploads/test.jpg",
+    )
+
+
+@patch("app.services.r2._get_s3_client")
+def test_get_display_url(mock_client_fn, app):
+    """get_display_url returns a presigned GET URL."""
+    mock_client = MagicMock()
+    mock_client.generate_presigned_url.return_value = "https://r2.example.com/display"
+    mock_client_fn.return_value = mock_client
+
+    with app.app_context():
+        url = r2_service.get_display_url("uploads/test.jpg")
+
+    assert url == "https://r2.example.com/display"
+
+
+def test_get_display_url_none_for_falsy(app):
+    """get_display_url returns None for empty/None image_url."""
+    with app.app_context():
+        assert r2_service.get_display_url(None) is None
+        assert r2_service.get_display_url("") is None

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -76,8 +76,6 @@ def test_dashboard_non_admin_forbidden(auth_client):
     assert response.status_code == 403
 
 
-
-
 def test_result_redirect_unauthenticated(client):
     """Result page redirects when not logged in."""
     response = client.get("/result")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 
 from PIL import Image
 
+from app.models import UserImage, db
+
 
 def test_index(client):
     """Test the index page."""
@@ -74,40 +76,6 @@ def test_dashboard_non_admin_forbidden(auth_client):
     assert response.status_code == 403
 
 
-def test_upload_no_file(auth_client):
-    """Upload without file returns 400."""
-    response = auth_client.post("/upload", data={})
-    assert response.status_code == 400
-    assert b"No file part" in response.data or b"error" in response.data.lower()
-
-
-def test_upload_empty_filename(auth_client):
-    """Upload with empty filename returns 400."""
-    response = auth_client.post(
-        "/upload",
-        data={"file": (io.BytesIO(b""), "")},
-        content_type="multipart/form-data",
-    )
-    assert response.status_code == 400
-
-
-def test_upload_success(auth_client, app):
-    """Upload with valid file returns success and image_id."""
-    img = Image.new("RGB", (10, 10), color="red")
-    buf = io.BytesIO()
-    img.save(buf, format="PNG")
-    buf.seek(0)
-    data = {"file": (buf, "photo.png")}
-    response = auth_client.post(
-        "/upload",
-        data=data,
-        content_type="multipart/form-data",
-    )
-    assert response.status_code == 200
-    data = response.get_json()
-    assert data.get("status") == "success"
-    assert "image_id" in data
-    assert "image_url" in data
 
 
 def test_result_redirect_unauthenticated(client):
@@ -198,9 +166,10 @@ def test_api_generate_wrong_user_403(auth_client, hairstyle, app):
     assert response.status_code == 403
 
 
+@patch("app.services.r2.download_bytes")
 @patch("app.routes.main.get_genai_client")
 def test_api_generate_no_gemini_key(
-    mock_get_client, auth_client, user_image, hairstyle
+    mock_get_client, mock_download, auth_client, user_image, hairstyle
 ):
     """API generate returns 500 when Gemini API key is missing."""
     mock_get_client.return_value = None
@@ -214,38 +183,14 @@ def test_api_generate_no_gemini_key(
     assert "error" in data
 
 
-@patch("app.routes.main.get_genai_client")
-@patch("app.routes.main.Image.open")
-def test_api_generate_success(
-    mock_image_open, mock_get_client, auth_client, user_image, hairstyle, app
-):
-    """API generate returns success when Gemini returns image."""
-    mock_image_open.return_value = MagicMock()
-    mock_client = MagicMock()
-    mock_part = MagicMock()
-    mock_part.inline_data = "present"
-    mock_img = MagicMock()
-    mock_part.as_image.return_value = mock_img
-    mock_client.models.generate_content.return_value = MagicMock(parts=[mock_part])
-    mock_get_client.return_value = mock_client
-    response = auth_client.post(
-        "/api/generate",
-        json={"user_image_id": user_image.id, "hairstyle_id": hairstyle.id},
-        content_type="application/json",
-    )
-    assert response.status_code == 200
-    data = response.get_json()
-    assert data.get("status") == "success"
-    assert "image_id" in data
-    assert "image_url" in data
-
-
+@patch("app.services.r2.download_bytes")
 @patch("app.routes.main.get_genai_client")
 @patch("app.routes.main.Image.open")
 def test_api_generate_exception_returns_500(
-    mock_image_open, mock_get_client, auth_client, user_image, hairstyle
+    mock_image_open, mock_get_client, mock_download, auth_client, user_image, hairstyle
 ):
     """API generate returns 500 when Gemini raises."""
+    mock_download.return_value = b"fake-bytes"
     mock_image_open.return_value = MagicMock()
     mock_get_client.return_value = MagicMock()
     mock_get_client.return_value.models.generate_content.side_effect = Exception(
@@ -261,12 +206,14 @@ def test_api_generate_exception_returns_500(
     assert "error" in data
 
 
+@patch("app.services.r2.download_bytes")
 @patch("app.routes.main.get_genai_client")
 @patch("app.routes.main.Image.open")
 def test_api_generate_no_image_in_response_returns_500(
-    mock_image_open, mock_get_client, auth_client, user_image, hairstyle
+    mock_image_open, mock_get_client, mock_download, auth_client, user_image, hairstyle
 ):
     """API generate returns 500 when model returns no image."""
+    mock_download.return_value = b"fake-bytes"
     mock_image_open.return_value = MagicMock()
     mock_client = MagicMock()
     mock_client.models.generate_content.return_value = MagicMock(parts=[])
@@ -277,3 +224,276 @@ def test_api_generate_no_image_in_response_returns_500(
         content_type="application/json",
     )
     assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# R2 presign / confirm endpoint tests
+# ---------------------------------------------------------------------------
+
+
+def _r2_auth_client(app):
+    """Create an authenticated test client using the app."""
+    from app.models import User, db
+
+    client = app.test_client()
+    with app.app_context():
+        u = User(
+            email="r2user@example.com",
+            username="r2user",
+            first_name="R2",
+            last_name="User",
+        )
+        db.session.add(u)
+        db.session.commit()
+        uid = u.id
+    with client.session_transaction() as sess:
+        sess["user_id"] = uid
+    return client, uid
+
+
+@patch("app.services.r2.get_presigned_put_url")
+@patch("app.services.r2.make_upload_key")
+def test_presign_returns_put_url(mock_key, mock_presign, app):
+    """POST /api/upload/presign returns put_url and upload_key."""
+    mock_key.return_value = "uploads/abc_photo.jpg"
+    mock_presign.return_value = "https://r2.example.com/put"
+    ac, _ = _r2_auth_client(app)
+
+    response = ac.post(
+        "/api/upload/presign",
+        json={"filename": "photo.jpg", "content_type": "image/jpeg"},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["put_url"] == "https://r2.example.com/put"
+    assert data["upload_key"] == "uploads/abc_photo.jpg"
+
+
+def test_presign_rejects_bad_content_type(app):
+    """POST /api/upload/presign rejects unsupported content types."""
+    ac, _ = _r2_auth_client(app)
+    response = ac.post(
+        "/api/upload/presign",
+        json={"filename": "file.txt", "content_type": "text/plain"},
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+    assert b"Unsupported" in response.data
+
+
+def test_presign_requires_auth(app):
+    """POST /api/upload/presign redirects when not authenticated."""
+    client = app.test_client()
+    response = client.post(
+        "/api/upload/presign",
+        json={"filename": "photo.jpg"},
+        content_type="application/json",
+    )
+    assert response.status_code == 302
+
+
+@patch("app.services.r2.get_display_url")
+def test_confirm_creates_user_image(mock_display, app):
+    """POST /api/upload/confirm creates a UserImage and returns display URL."""
+    mock_display.return_value = "https://r2.example.com/get/uploads/abc.jpg"
+    ac, uid = _r2_auth_client(app)
+
+    response = ac.post(
+        "/api/upload/confirm",
+        json={"upload_key": "uploads/abc_photo.jpg"},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "success"
+    assert data["image_url"] == "https://r2.example.com/get/uploads/abc.jpg"
+    assert "image_id" in data
+
+    with app.app_context():
+        ui = db.session.get(UserImage, data["image_id"])
+        assert ui is not None
+        assert ui.image_url == "uploads/abc_photo.jpg"
+        assert ui.user_id == uid
+
+
+def test_confirm_rejects_invalid_key(app):
+    """POST /api/upload/confirm rejects keys without uploads/ prefix."""
+    ac, _ = _r2_auth_client(app)
+    response = ac.post(
+        "/api/upload/confirm",
+        json={"upload_key": "malicious/path"},
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+
+
+def test_confirm_rejects_missing_key(app):
+    """POST /api/upload/confirm rejects missing upload_key."""
+    ac, _ = _r2_auth_client(app)
+    response = ac.post(
+        "/api/upload/confirm",
+        json={},
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# R2-enabled generate tests
+# ---------------------------------------------------------------------------
+
+
+@patch("app.services.r2.get_display_url")
+@patch("app.services.r2.upload_bytes")
+@patch("app.services.r2.download_bytes")
+@patch("app.routes.main.get_genai_client")
+def test_api_generate_success(
+    mock_get_client, mock_download, mock_upload, mock_display, app
+):
+    """Generate reads from R2, uploads result, returns presigned URL."""
+    from app.models import Hairstyle, User, UserImage, db
+
+    ac = app.test_client()
+    with app.app_context():
+        u = User(
+            email="gen@example.com",
+            username="genuser",
+            first_name="Gen",
+            last_name="User",
+        )
+        db.session.add(u)
+        db.session.commit()
+        h = Hairstyle(
+            name="R2 Cut",
+            description="A test style",
+            category="MODERN",
+            image_url="test.png",
+        )
+        ui = UserImage(user_id=u.id, image_url="uploads/selfie.jpg")
+        db.session.add_all([h, ui])
+        db.session.commit()
+        uid, ui_id, h_id = u.id, ui.id, h.id
+
+    with ac.session_transaction() as sess:
+        sess["user_id"] = uid
+
+    img = Image.new("RGB", (10, 10), color="blue")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    mock_download.return_value = buf.getvalue()
+
+    mock_part = MagicMock()
+    mock_part.inline_data = MagicMock(data=b"fake-png-bytes", mime_type="image/png")
+    mock_part.as_image.return_value = MagicMock()
+    mock_client = MagicMock()
+    mock_client.models.generate_content.return_value = MagicMock(parts=[mock_part])
+    mock_get_client.return_value = mock_client
+
+    mock_display.return_value = "https://r2.example.com/get/result.png"
+
+    response = ac.post(
+        "/api/generate",
+        json={"user_image_id": ui_id, "hairstyle_id": h_id},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "success"
+    assert data["image_url"] == "https://r2.example.com/get/result.png"
+
+    mock_download.assert_called_once_with("uploads/selfie.jpg")
+    mock_upload.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# R2-enabled result / gallery display URL tests
+# ---------------------------------------------------------------------------
+
+
+@patch("app.services.r2.get_display_url")
+def test_result_uses_r2_display_url(mock_display, app):
+    """Result page passes presigned URL to template."""
+    from app.models import GeneratedImage, Hairstyle, User, UserImage, db
+
+    ac = app.test_client()
+    with app.app_context():
+        u = User(
+            email="res@example.com",
+            username="resuser",
+            first_name="R",
+            last_name="U",
+        )
+        db.session.add(u)
+        db.session.commit()
+        h = Hairstyle(
+            name="Res Cut",
+            description="A style",
+            category="MODERN",
+            image_url="test.png",
+        )
+        ui = UserImage(user_id=u.id, image_url="uploads/photo.jpg")
+        db.session.add_all([h, ui])
+        db.session.commit()
+        gi = GeneratedImage(
+            user_id=u.id,
+            user_image_id=ui.id,
+            hairstyle_id=h.id,
+            image_url="uploads/gen_result.png",
+        )
+        db.session.add(gi)
+        db.session.commit()
+        uid, gi_id = u.id, gi.id
+
+    with ac.session_transaction() as sess:
+        sess["user_id"] = uid
+
+    mock_display.return_value = "https://r2.example.com/display/gen_result.png"
+
+    response = ac.get(f"/result/{gi_id}")
+    assert response.status_code == 200
+    assert b"https://r2.example.com/display/gen_result.png" in response.data
+
+
+@patch("app.services.r2.get_display_url")
+def test_gallery_uses_r2_display_urls(mock_display, app):
+    """Gallery passes presigned URLs for all images."""
+    from app.models import GeneratedImage, Hairstyle, User, UserImage, db
+
+    ac = app.test_client()
+    with app.app_context():
+        u = User(
+            email="gal@example.com",
+            username="galuser",
+            first_name="G",
+            last_name="U",
+        )
+        db.session.add(u)
+        db.session.commit()
+        h = Hairstyle(
+            name="Gal Cut",
+            description="A style",
+            category="MODERN",
+            image_url="test.png",
+        )
+        ui = UserImage(user_id=u.id, image_url="uploads/photo.jpg")
+        db.session.add_all([h, ui])
+        db.session.commit()
+        gi = GeneratedImage(
+            user_id=u.id,
+            user_image_id=ui.id,
+            hairstyle_id=h.id,
+            image_url="uploads/gen_gal.png",
+        )
+        db.session.add(gi)
+        db.session.commit()
+        uid = u.id
+
+    with ac.session_transaction() as sess:
+        sess["user_id"] = uid
+
+    mock_display.return_value = "https://r2.example.com/display/gen_gal.png"
+
+    response = ac.get("/gallery")
+    assert response.status_code == 200
+    assert b"https://r2.example.com/display/gen_gal.png" in response.data

--- a/uv.lock
+++ b/uv.lock
@@ -45,6 +45,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.68"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ae/60c642aa5413e560b671da825329f510b29a77274ed0f580bde77562294d/boto3-1.42.68.tar.gz", hash = "sha256:3f349f967ab38c23425626d130962bcb363e75f042734fe856ea8c5a00eef03c", size = 112761, upload-time = "2026-03-13T19:32:17.137Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/f6/dc6e993479dbb597d68223fbf61cb026511737696b15bd7d2a33e9b2c24f/boto3-1.42.68-py3-none-any.whl", hash = "sha256:dbff353eb7dc93cbddd7926ed24793e0174c04adbe88860dfa639568442e4962", size = 140556, upload-time = "2026-03-13T19:32:14.951Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.68"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/22/87502d5fbbfa8189406a617b30b1e2a3dc0ab2669f7268e91b385c1c1c7a/botocore-1.42.68.tar.gz", hash = "sha256:3951c69e12ac871dda245f48dac5c7dd88ea1bfdd74a8879ec356cf2874b806a", size = 14994514, upload-time = "2026-03-13T19:32:03.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/2a/1428f6594799780fe6ee845d8e6aeffafe026cd16a70c878684e2dcbbfc8/botocore-1.42.68-py3-none-any.whl", hash = "sha256:9df7da26374601f890e2f115bfa573d65bf15b25fe136bb3aac809f6145f52ab", size = 14668816, upload-time = "2026-03-13T19:31:58.572Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -414,6 +442,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -651,6 +688,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -697,6 +746,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/3a/950367aee7c69027f4f422059227b290ed780366b6aecee5de5039d50fa8/ruff-0.15.5-py3-none-win32.whl", hash = "sha256:732e5ee1f98ba5b3679029989a06ca39a950cced52143a0ea82a2102cb592b74", size = 10551676, upload-time = "2026-03-05T20:06:13.705Z" },
     { url = "https://files.pythonhosted.org/packages/b8/00/bf077a505b4e649bdd3c47ff8ec967735ce2544c8e4a43aba42ee9bf935d/ruff-0.15.5-py3-none-win_amd64.whl", hash = "sha256:821d41c5fa9e19117616c35eaa3f4b75046ec76c65e7ae20a333e9a8696bc7fe", size = 11678972, upload-time = "2026-03-05T20:06:45.379Z" },
     { url = "https://files.pythonhosted.org/packages/fe/4e/cd76eca6db6115604b7626668e891c9dd03330384082e33662fb0f113614/ruff-0.15.5-py3-none-win_arm64.whl", hash = "sha256:b498d1c60d2fe5c10c45ec3f698901065772730b411f164ae270bb6bfcc4740b", size = 10965572, upload-time = "2026-03-05T20:06:16.984Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -749,6 +819,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "boto3" },
     { name = "flask" },
     { name = "flask-sqlalchemy" },
     { name = "google-genai" },
@@ -770,6 +841,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "authlib", specifier = ">=1.6.9" },
+    { name = "boto3", specifier = ">=1.38.0" },
     { name = "flask", specifier = ">=3.1.3" },
     { name = "flask-sqlalchemy", specifier = ">=3.1.1" },
     { name = "google-genai", specifier = ">=1.66.0" },


### PR DESCRIPTION

## Description

This PR migrates image storage from local disk to **Cloudflare R2** (S3-compatible object storage). User uploads use presigned PUT URLs for direct client-to-R2 uploads, and generated images are stored in and served from R2 via presigned GET URLs.

## Related Issues

Closes #1 

## Changes Made

- [X] Add boto3 dependency for S3-compatible API access
- [X] Add R2 configuration (account ID, access key, secret key, bucket name) in `config.py` and `.env.example`
- [X] Add `app/services/r2.py` with presigned PUT/GET, upload/download, and key generation
- [X] Replace `/upload` POST with presigned flow: `/api/upload/presign` and `/api/upload/confirm`
- [X] Update Style Studio frontend to use presign → PUT → confirm flow instead of multipart form upload
- [X] Update generate flow to read source images from R2 and write generated images to R2
- [X] Update result and gallery pages to use presigned display URLs instead of `/static/uploads/`
- [X] Add R2 service tests (`tests/test_r2_service.py`)
- [X] Add R2 credentials to `TestConfig` in `conftest.py`
- [X] Update route tests for presign/confirm endpoints and R2-backed generate/result/gallery

## Testing & Verification

- Run `uv run pytest tests/ -v --cov=app` — all 55 tests pass with 96% test coverage.
- R2 service tests cover key generation, presigned URLs, upload/download, and `get_display_url`.
- Route tests cover presign (success, bad content type, auth), confirm (success, invalid key, missing key), generate with R2 mocks, and result/gallery display URLs.
- R2 calls are mocked in tests; no live R2 credentials required.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] My code follows the style guidelines of this project
- [X] My changes generate no new warnings