### PR TITLE
feat: store generated images in WEBP format

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -414,8 +414,14 @@ def generate():
 
         result_key = r2_service.make_generated_key()
         image_bytes = image_part.inline_data.data
-        mime_type = image_part.inline_data.mime_type or "image/png"
-        r2_service.upload_bytes(result_key, image_bytes, mime_type)
+
+        # Transcode to lossless WebP
+        gen_image_pil = Image.open(io.BytesIO(image_bytes))
+        webp_io = io.BytesIO()
+        gen_image_pil.save(webp_io, format="WEBP", lossless=True)
+        webp_bytes = webp_io.getvalue()
+
+        r2_service.upload_bytes(result_key, webp_bytes, "image/webp")
         result_url = result_key
 
         gen_img = GeneratedImage(

--- a/app/services/r2.py
+++ b/app/services/r2.py
@@ -27,7 +27,7 @@ def make_upload_key(filename):
 
 def make_generated_key():
     """Generate a unique R2 object key for a generated image."""
-    return f"uploads/gen_{uuid.uuid4()}.png"
+    return f"uploads/gen_{uuid.uuid4()}.webp"
 
 
 def get_presigned_put_url(key, content_type="image/jpeg", expires_in=3600):
@@ -57,7 +57,7 @@ def get_presigned_get_url(key, expires_in=3600):
     )
 
 
-def upload_bytes(key, data, content_type="image/png"):
+def upload_bytes(key, data, content_type="image/webp"):
     """Upload raw bytes to R2 under the given key."""
     client = _get_s3_client()
     client.put_object(

--- a/app/templates/gallery.html
+++ b/app/templates/gallery.html
@@ -33,7 +33,7 @@
                             <i class="bi bi-eye"></i>
                         </a>
                         <a href="{{ display_urls[img.id] }}"
-                            download="truehair_{{ img.hairstyle.name | replace(' ', '_') }}_{{ img.id }}.png"
+                            download="truehair_{{ img.hairstyle.name | replace(' ', '_') }}_{{ img.id }}.webp"
                             class="btn btn-outline-yellow btn-sm rounded-circle d-flex align-items-center justify-content-center"
                             style="width: 32px; height: 32px;" title="Download">
                             <i class="bi bi-download"></i>

--- a/app/templates/result.html
+++ b/app/templates/result.html
@@ -49,7 +49,7 @@
                 </button>
                 {% if latest_gen and image_display_url %}
                 <a href="{{ image_display_url }}"
-                    download="truehair_{{ latest_gen.hairstyle.name | replace(' ', '_') }}_{{ latest_gen.id }}.png"
+                    download="truehair_{{ latest_gen.hairstyle.name | replace(' ', '_') }}_{{ latest_gen.id }}.webp"
                     class="btn btn-dark border border-secondary border-opacity-50 rounded-3 d-flex align-items-center justify-content-center px-4 py-3"
                     style="background-color: #2a2a2d;" title="Download Result">
                     <i class="bi bi-download text-white fs-5"></i>

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -45,7 +45,7 @@ def test_generated_image_relationships(app, user, user_image, hairstyle):
             user_id=user.id,
             user_image_id=user_image.id,
             hairstyle_id=hairstyle.id,
-            image_url="uploads/gen.png",
+            image_url="uploads/gen.webp",
         )
         db.session.add(gen)
         db.session.commit()

--- a/tests/test_r2_service.py
+++ b/tests/test_r2_service.py
@@ -22,11 +22,11 @@ def test_make_upload_key_default_when_empty(app):
 
 
 def test_make_generated_key_format(app):
-    """Generated key has uploads/gen_ prefix and .png extension."""
+    """Generated key has uploads/gen_ prefix and .webp extension."""
     with app.app_context():
         key = r2_service.make_generated_key()
         assert key.startswith("uploads/gen_")
-        assert key.endswith(".png")
+        assert key.endswith(".webp")
 
 
 def test_make_upload_key_unique(app):
@@ -87,13 +87,13 @@ def test_upload_bytes(mock_client_fn, app):
     mock_client_fn.return_value = mock_client
 
     with app.app_context():
-        r2_service.upload_bytes("uploads/gen_abc.png", b"fake-image", "image/png")
+        r2_service.upload_bytes("uploads/gen_abc.webp", b"fake-image", "image/webp")
 
     mock_client.put_object.assert_called_once_with(
         Bucket="test-bucket",
-        Key="uploads/gen_abc.png",
+        Key="uploads/gen_abc.webp",
         Body=b"fake-image",
-        ContentType="image/png",
+        ContentType="image/webp",
     )
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -382,13 +382,13 @@ def test_api_generate_success(
     mock_download.return_value = buf.getvalue()
 
     mock_part = MagicMock()
-    mock_part.inline_data = MagicMock(data=b"fake-png-bytes", mime_type="image/png")
+    mock_part.inline_data = MagicMock(data=buf.getvalue(), mime_type="image/png")
     mock_part.as_image.return_value = MagicMock()
     mock_client = MagicMock()
     mock_client.models.generate_content.return_value = MagicMock(parts=[mock_part])
     mock_get_client.return_value = mock_client
 
-    mock_display.return_value = "https://r2.example.com/get/result.png"
+    mock_display.return_value = "https://r2.example.com/get/result.webp"
 
     response = ac.post(
         "/api/generate",
@@ -398,10 +398,15 @@ def test_api_generate_success(
     assert response.status_code == 200
     data = response.get_json()
     assert data["status"] == "success"
-    assert data["image_url"] == "https://r2.example.com/get/result.png"
+    assert data["image_url"] == "https://r2.example.com/get/result.webp"
 
     mock_download.assert_called_once_with("uploads/selfie.jpg")
     mock_upload.assert_called_once()
+    
+    uploaded_key = mock_upload.call_args[0][0]
+    uploaded_mime = mock_upload.call_args[0][2]
+    assert uploaded_key.endswith(".webp")
+    assert uploaded_mime == "image/webp"
 
 
 # ---------------------------------------------------------------------------
@@ -437,7 +442,7 @@ def test_result_uses_r2_display_url(mock_display, app):
             user_id=u.id,
             user_image_id=ui.id,
             hairstyle_id=h.id,
-            image_url="uploads/gen_result.png",
+            image_url="uploads/gen_result.webp",
         )
         db.session.add(gi)
         db.session.commit()
@@ -446,11 +451,11 @@ def test_result_uses_r2_display_url(mock_display, app):
     with ac.session_transaction() as sess:
         sess["user_id"] = uid
 
-    mock_display.return_value = "https://r2.example.com/display/gen_result.png"
+    mock_display.return_value = "https://r2.example.com/display/gen_result.webp"
 
     response = ac.get(f"/result/{gi_id}")
     assert response.status_code == 200
-    assert b"https://r2.example.com/display/gen_result.png" in response.data
+    assert b"https://r2.example.com/display/gen_result.webp" in response.data
 
 
 @patch("app.services.r2.get_display_url")
@@ -481,7 +486,7 @@ def test_gallery_uses_r2_display_urls(mock_display, app):
             user_id=u.id,
             user_image_id=ui.id,
             hairstyle_id=h.id,
-            image_url="uploads/gen_gal.png",
+            image_url="uploads/gen_gal.webp",
         )
         db.session.add(gi)
         db.session.commit()
@@ -490,8 +495,8 @@ def test_gallery_uses_r2_display_urls(mock_display, app):
     with ac.session_transaction() as sess:
         sess["user_id"] = uid
 
-    mock_display.return_value = "https://r2.example.com/display/gen_gal.png"
+    mock_display.return_value = "https://r2.example.com/display/gen_gal.webp"
 
     response = ac.get("/gallery")
     assert response.status_code == 200
-    assert b"https://r2.example.com/display/gen_gal.png" in response.data
+    assert b"https://r2.example.com/display/gen_gal.webp" in response.data

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -402,7 +402,7 @@ def test_api_generate_success(
 
     mock_download.assert_called_once_with("uploads/selfie.jpg")
     mock_upload.assert_called_once()
-    
+
     uploaded_key = mock_upload.call_args[0][0]
     uploaded_mime = mock_upload.call_args[0][2]
     assert uploaded_key.endswith(".webp")


### PR DESCRIPTION
## Description
This PR transitions the file format of generated images from PNG to lossless WebP in order to reduce storage overhead in Cloudflare R2 and improves network transfer speeds.

## Related Issues
Closes #18 

## Changes Made
- [x] Updated `app/services/r2.py` to use `.webp` extensions and `image/webp` MIME type for generated keys.
- [x] Implemented transcoding logic in `app/routes/main.py` using Pillow to convert raw bytes to lossless WebP.
- [x] Updated `app/templates/result.html` and `app/templates/gallery.html` to suggest `.webp` filenames for downloads.
- [x] Updated unit and integration tests in `tests/` to verify WebP key generation, transcoding, and correct R2 metadata.

## Testing & Verification
- Ran full test suite using `uv run pytest`.
- Verified 55/55 tests passing.
- Confirmed correct headers (`Content-Type: image/webp`) are passed to R2 client in mock assertions.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings