### PR TITLE
Docs: add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,34 @@
+name: Bug Report
+description: File a report to help us improve
+title: "[BUG]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: How do we trigger this bug?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: Expected vs Actual Behavior
+      description: What did you expect to happen, and what actually happened?
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Info
+      description: OS, Browser, Version, etc.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,24 @@
+name: Feature Request
+description: Suggest an idea for this project
+title: "[FEATURE]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a problem? Please describe.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Description
+<!-- Provide a brief summary of the changes and the motivation behind them. -->
+
+## Related Issues
+<!-- Link to related issues using "Closes #123" or "Fixes #123" -->
+
+## Changes Made
+- [ ] Change description 1
+- [ ] Change description 2
+
+## Testing & Verification
+<!-- Describe how you tested these changes. Include steps to reproduce if necessary. -->
+
+## Checklist
+- [ ] I have performed a self-review of my own code
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] My code follows the style guidelines of this project
+- [ ] My changes generate no new warnings


### PR DESCRIPTION
## Description
This PR adds GitHub issues and pull request templates to the repository so all collaborators can follow the same format when creating issues and pull requests.

## Related Issues
Closes #9 

## Changes Made
- [X] Add GitHub Pull Request template `.github/pull_request_template.md` with sections for description, related issues, changes made, testing & verification, and Checklist of tasks.
- [X] Add GitHub issue template for bug reports `.github/ISSUE_TEMPLATE/bug-report.yml`
- [X] Add GitHub issue template for feature requests `.github/ISSUE_TEMPLATE/feature-request.yml`

## Testing & Verification
<!-- Describe how you tested these changes. Include steps to reproduce if necessary. -->

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] My code follows the style guidelines of this project
- [X] My changes generate no new warnings
