### PR TITLE
feat(auth): add IRB informed consent modal and enforcement

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -32,6 +32,20 @@ class Visit(db.Model):
         return f"<Visit id={self.id} page='{self.page}' timestamp={self.timestamp}>"
 
 
+class Consent(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.Integer, db.ForeignKey("user.id"), nullable=False, unique=True
+    )
+    full_name = db.Column(db.String(200), nullable=False)
+    experiment_group = db.Column(db.String(20), nullable=False)
+    consented_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    user = db.relationship(
+        "User", backref=db.backref("consent", uselist=False, lazy=True)
+    )
+
+
 class Hairstyle(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False)

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -21,6 +21,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
 from app.models import (
+    Consent,
     GeneratedImage,
     Hairstyle,
     Rating,
@@ -60,6 +61,20 @@ def login_required(f):
     return decorated_function
 
 
+def consent_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if "user_id" not in session:
+            return redirect(url_for("auth.login", next=request.url))
+        user_id = session["user_id"]
+        has_consented = Consent.query.filter_by(user_id=user_id).first() is not None
+        if not has_consented:
+            return redirect(url_for("main.style_studio"))
+        return f(*args, **kwargs)
+
+    return decorated_function
+
+
 def admin_required(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
@@ -76,11 +91,15 @@ def admin_required(f):
 @main_bp.app_context_processor
 def inject_user():
     user = None
+    has_consented = False
     if "user_id" in session:
         user = db.session.get(User, session["user_id"])
+        if user:
+            has_consented = Consent.query.filter_by(user_id=user.id).first() is not None
     return {
         "current_user": user,
         "experiment_group": session.get("experiment_group"),
+        "has_consented": has_consented,
     }
 
 
@@ -144,6 +163,7 @@ def upload_confirm():
 
 @main_bp.route("/stylists")
 @login_required
+@consent_required
 def stylists():
     log_visit("Stylist Directory")
     query = request.args.get("q", "").strip()
@@ -325,6 +345,7 @@ def dashboard():
 @main_bp.route("/result")
 @main_bp.route("/result/<int:image_id>")
 @login_required
+@consent_required
 def result(image_id=None):
     log_visit("Results Page")
     if image_id:
@@ -356,6 +377,7 @@ def result(image_id=None):
 
 @main_bp.route("/gallery")
 @login_required
+@consent_required
 def gallery():
     log_visit("My Gallery")
     images = (
@@ -522,3 +544,48 @@ def api_rate():
         db.session.commit()
 
     return jsonify({"status": "success", "rating": rating_val})
+
+
+@main_bp.route("/api/consent", methods=["POST"])
+@login_required
+def submit_consent():
+    data = request.get_json(silent=True) or {}
+    full_name = data.get("full_name", "").strip()
+
+    if not full_name or len(full_name) < 2:
+        return jsonify({"error": "Full name must be at least 2 characters"}), 400
+
+    user_id = session["user_id"]
+    existing = Consent.query.filter_by(user_id=user_id).first()
+
+    if existing:
+        return jsonify({
+            "status": "success",
+            "consented_at": existing.consented_at.isoformat()
+        })
+
+    user = db.session.get(User, user_id)
+    experiment_group = user.experiment_group or "unknown"
+
+    consent = Consent(
+        user_id=user_id,
+        full_name=full_name,
+        experiment_group=experiment_group
+    )
+    db.session.add(consent)
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        existing = Consent.query.filter_by(user_id=user_id).first()
+        if existing:
+            return jsonify({
+                "status": "success",
+                "consented_at": existing.consented_at.isoformat()
+            })
+        return jsonify({"error": "Unable to save consent"}), 500
+
+    return jsonify({
+        "status": "success",
+        "consented_at": consent.consented_at.isoformat()
+    })

--- a/app/templates/style_studio.html
+++ b/app/templates/style_studio.html
@@ -5,6 +5,49 @@
 {% block body_class %}bg-studio{% endblock %}
 
 {% block content %}
+<!-- IRB Consent Modal -->
+{% if not has_consented %}
+<div class="modal fade" id="irbConsentModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="irbConsentModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content bg-dark text-light border-secondary">
+            <div class="modal-header border-secondary">
+                <h5 class="modal-title text-yellow fw-bold" id="irbConsentModalLabel">Research Study Consent Form</h5>
+            </div>
+            <div class="modal-body" style="font-size: 0.9rem; line-height: 1.6;">
+                <p><strong>Purpose of the Study:</strong> We are evaluating the usability and effectiveness of AI-generated hairstyle visualizations. By participating, you will help us understand how users interact with these tools.</p>
+                
+                <p><strong>What You Will Do:</strong> You will be asked to upload a photo, select hairstyles, and view AI-generated results. We will record your interactions, choices, and the images generated during your session.</p>
+                
+                <p><strong>Data Collection & Privacy:</strong> Your uploaded photos and generated images will be stored securely. We will collect usage data (e.g., clicks, time spent) for research purposes. Your personal identity will be kept confidential in any published results.</p>
+                
+                <p><strong>Voluntary Participation:</strong> Your participation is completely voluntary. You may stop using the application at any time without penalty.</p>
+                
+                <p><strong>Risks & Benefits:</strong> There are no foreseeable risks beyond those of typical web browsing. While you may not directly benefit, your participation will contribute to the improvement of AI design tools.</p>
+
+                <hr class="border-secondary my-4">
+
+                <form id="consentForm">
+                    <div class="mb-3">
+                        <label for="consentFullName" class="form-label fw-bold">Full Name (electronic signature)</label>
+                        <input type="text" class="form-control bg-black text-light border-secondary" id="consentFullName" placeholder="Type your full name" required minlength="2">
+                        <div class="invalid-feedback">Please enter your full name (at least 2 characters).</div>
+                    </div>
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" id="consentCheckbox" required>
+                        <label class="form-check-label" for="consentCheckbox">
+                            I have read and understand the above information and voluntarily agree to participate.
+                        </label>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer border-secondary">
+                <button type="button" class="btn btn-yellow fw-bold w-100" id="btnSubmitConsent" disabled>I Agree & Continue</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <div class="container-fluid px-4 py-4">
     <div class="row g-4">
 
@@ -126,6 +169,58 @@
 
 <script>
     document.addEventListener('DOMContentLoaded', function () {
+        // IRB Consent Modal Logic
+        const consentModalEl = document.getElementById('irbConsentModal');
+        if (consentModalEl) {
+            const consentModal = new bootstrap.Modal(consentModalEl);
+            consentModal.show();
+
+            const consentFullName = document.getElementById('consentFullName');
+            const consentCheckbox = document.getElementById('consentCheckbox');
+            const btnSubmitConsent = document.getElementById('btnSubmitConsent');
+
+            function checkConsentValidity() {
+                const name = consentFullName.value.trim();
+                btnSubmitConsent.disabled = !(name.length >= 2 && consentCheckbox.checked);
+            }
+
+            consentFullName.addEventListener('input', checkConsentValidity);
+            consentCheckbox.addEventListener('change', checkConsentValidity);
+
+            btnSubmitConsent.addEventListener('click', function() {
+                const name = consentFullName.value.trim();
+                if (name.length < 2 || !consentCheckbox.checked) return;
+
+                btnSubmitConsent.disabled = true;
+                btnSubmitConsent.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Submitting...';
+
+                fetch('{{ url_for("main.submit_consent") }}', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ full_name: name })
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.status === 'success') {
+                        consentModal.hide();
+                        // Optionally trigger heartbeat here if implemented
+                    } else {
+                        alert(data.error || 'Failed to submit consent. Please try again.');
+                        btnSubmitConsent.disabled = false;
+                        btnSubmitConsent.innerHTML = 'I Agree & Continue';
+                    }
+                })
+                .catch(err => {
+                    console.error(err);
+                    alert('An error occurred. Please try again.');
+                    btnSubmitConsent.disabled = false;
+                    btnSubmitConsent.innerHTML = 'I Agree & Continue';
+                });
+            });
+        }
+
         let selectedHairstyleId = null;
         let uploadedImageId = null;
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,8 @@ def runner(app):
 
 @pytest.fixture
 def user(app):
+    from app.models import Consent
+
     with app.app_context():
         u = User(
             email="test@example.com",
@@ -50,6 +52,15 @@ def user(app):
         )
         db.session.add(u)
         db.session.commit()
+        
+        c = Consent(
+            user_id=u.id,
+            full_name="Test User",
+            experiment_group="control"
+        )
+        db.session.add(c)
+        db.session.commit()
+        
         db.session.refresh(u)
         return u
 
@@ -74,6 +85,28 @@ def admin_user(app):
 def auth_client(client, user):
     with client.session_transaction() as sess:
         sess["user_id"] = user.id
+    return client
+
+
+@pytest.fixture
+def no_consent_user(app):
+    with app.app_context():
+        u = User(
+            email="noconsent@example.com",
+            username="noconsentuser",
+            first_name="No",
+            last_name="Consent",
+        )
+        db.session.add(u)
+        db.session.commit()
+        db.session.refresh(u)
+        return u
+
+
+@pytest.fixture
+def no_consent_client(client, no_consent_user):
+    with client.session_transaction() as sess:
+        sess["user_id"] = no_consent_user.id
     return client
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -108,6 +108,13 @@ def test_gallery_authenticated(auth_client):
     assert response.status_code == 200
 
 
+def test_gallery_no_consent_redirects(no_consent_client):
+    """Users without consent are redirected to style studio."""
+    response = no_consent_client.get("/gallery")
+    assert response.status_code == 302
+    assert "/style-studio" in response.headers["Location"]
+
+
 def test_api_generate_redirect_unauthenticated(client):
     """API generate requires login."""
     response = client.post(
@@ -607,3 +614,61 @@ def test_api_rate_updates_existing(auth_client, generated_image, app):
             Rating.query.filter_by(generated_image_id=generated_image.id).one().rating
             == 5
         )
+
+
+def test_api_consent_success(no_consent_client, app):
+    """Valid consent submission creates a record."""
+    from app.models import Consent
+
+    response = no_consent_client.post(
+        "/api/consent",
+        json={"full_name": "John Doe"},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "success"
+    assert "consented_at" in data
+
+    with app.app_context():
+        consent = Consent.query.filter_by(full_name="John Doe").first()
+        assert consent is not None
+
+
+def test_api_consent_invalid_name(no_consent_client):
+    """Invalid name returns 400."""
+    response = no_consent_client.post(
+        "/api/consent",
+        json={"full_name": "J"},
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+    assert "error" in response.get_json()
+
+
+def test_api_consent_duplicate(no_consent_client, app):
+    """Duplicate consent submission returns success with existing record."""
+    from app.models import Consent
+
+    # First submission
+    no_consent_client.post(
+        "/api/consent",
+        json={"full_name": "John Doe"},
+        content_type="application/json",
+    )
+
+    # Second submission
+    response = no_consent_client.post(
+        "/api/consent",
+        json={"full_name": "Jane Doe"},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "success"
+
+    with app.app_context():
+        consents = Consent.query.filter_by(full_name="John Doe").all()
+        assert len(consents) == 1
+        # Jane Doe should not exist because John Doe was already created for this user
+        assert Consent.query.filter_by(full_name="Jane Doe").first() is None


### PR DESCRIPTION
## Description
This PR implements the IRB informed consent requirement. It introduces a non-dismissible consent modal that appears immediately after a user logs in, blocking access to the experiment features (Style Studio, Stylists, Gallery, and Results) until they provide an electronic signature (their typed full name). 
## Related Issues
Closes #35 
## Changes Made
- [x] **Database:** Added a `Consent` model to securely store the user's electronic signature, experiment group, and a server-generated timestamp.
- [x] **API:** Created the `POST /api/consent` endpoint to handle consent submissions, including validation and duplicate handling.
- [x] **Access Control:** Implemented a `@consent_required` decorator to protect the `/stylists`, `/gallery`, and `/result` routes, redirecting unconsented users to the Style Studio.
- [x] **Frontend:** Added a static, non-dismissible IRB consent modal to `style_studio.html` that enforces a minimum 2-character name and a checkbox agreement before submission.
- [x] **Context:** Updated the `inject_user` context processor to globally provide a `has_consented` flag to all templates.
## Testing & Verification
- Added comprehensive unit tests in `tests/test_routes.py` for the new `POST /api/consent` endpoint (testing success, invalid names, and duplicate submissions).
- Added tests verifying that the `@consent_required` decorator properly redirects users without a consent record.
- Added `no_consent_user` and `no_consent_client` fixtures to `conftest.py` to facilitate testing of the unconsented state.
- Manually verified that the modal cannot be bypassed (static backdrop, no keyboard escape) and that the submit button remains disabled until valid input is provided.
## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced consent requirement for accessing style galleries, stylist profiles, and result pages.
  * New consent modal on style studio page collects user's full name and consent agreement before granting access to gated features.
  * Added consent submission endpoint that validates and persists user consent information.

* **Tests**
  * Added test coverage for consent flows and access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->