### PR TITLE
fix: add safety checks to migrations to prevent Heroku deploy failures

### DIFF
--- a/migrations/versions/85832af9eba3_add_reference_image_id_to_generatedimage.py
+++ b/migrations/versions/85832af9eba3_add_reference_image_id_to_generatedimage.py
@@ -8,6 +8,7 @@ Create Date: 2026-04-13 11:30:02.438610
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.engine.reflection import Inspector
 
 
 # revision identifiers, used by Alembic.
@@ -18,17 +19,29 @@ depends_on = None
 
 
 def upgrade():
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
+    columns = [col["name"] for col in inspector.get_columns("generated_image")]
+
     with op.batch_alter_table("generated_image", schema=None) as batch_op:
-        batch_op.add_column(
-            sa.Column("reference_image_id", sa.Integer(), nullable=True)
-        )
+        if "reference_image_id" not in columns:
+            batch_op.add_column(
+                sa.Column("reference_image_id", sa.Integer(), nullable=True)
+            )
+
+        # Always safe to alter_column if it's already nullable, but let's check
         batch_op.alter_column("hairstyle_id", existing_type=sa.INTEGER(), nullable=True)
-        batch_op.create_foreign_key(
-            "fk_generated_image_reference_image_id",
-            "user_image",
-            ["reference_image_id"],
-            ["id"],
-        )
+
+        # Check if the foreign key already exists
+        fks = inspector.get_foreign_keys("generated_image")
+        fk_names = [fk["name"] for fk in fks]
+        if "fk_generated_image_reference_image_id" not in fk_names:
+            batch_op.create_foreign_key(
+                "fk_generated_image_reference_image_id",
+                "user_image",
+                ["reference_image_id"],
+                ["id"],
+            )
 
 
 def downgrade():

--- a/migrations/versions/ae9086542a24_add_experiment_session_rating_and_.py
+++ b/migrations/versions/ae9086542a24_add_experiment_session_rating_and_.py
@@ -49,25 +49,26 @@ def upgrade():
             sa.PrimaryKeyConstraint("id"),
         )
 
-    op.create_table(
-        "rating",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("user_id", sa.Integer(), nullable=False),
-        sa.Column("generated_image_id", sa.Integer(), nullable=False),
-        sa.Column("rating", sa.Integer(), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
-        sa.CheckConstraint("rating >= 1 AND rating <= 5", name="ck_rating_range"),
-        sa.ForeignKeyConstraint(
-            ["generated_image_id"],
-            ["generated_image.id"],
-        ),
-        sa.ForeignKeyConstraint(
-            ["user_id"],
-            ["user.id"],
-        ),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("generated_image_id"),
-    )
+    if "rating" not in existing_tables:
+        op.create_table(
+            "rating",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("generated_image_id", sa.Integer(), nullable=False),
+            sa.Column("rating", sa.Integer(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+            sa.CheckConstraint("rating >= 1 AND rating <= 5", name="ck_rating_range"),
+            sa.ForeignKeyConstraint(
+                ["generated_image_id"],
+                ["generated_image.id"],
+            ),
+            sa.ForeignKeyConstraint(
+                ["user_id"],
+                ["user.id"],
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("generated_image_id"),
+        )
 
 
 def downgrade():


### PR DESCRIPTION
## Description
This PR addresses the recurring Heroku deployment failures caused by duplicate table/column errors during database migrations. 

The previous fix in PR #42 missed a check for the `rating` table, which caused the latest deployment (v43) to fail. Additionally, this PR adds safety checks to the `85832af9eba3` migration which adds the `reference_image_id` column to the `generated_image` table.

## Changes Made
- [x] **Updated Migration `ae9086542a24`**: Added a safety check to only create the `rating` table if it doesn't already exist.
- [x] **Updated Migration `85832af9eba3`**: Added safety checks to check if the `reference_image_id` column or the corresponding foreign key already exist before attempting to add them.
- [x] **Standardized Checks**: Used SQLAlchemy `Inspector` to perform reliable checks against the database state across different database engines (SQLite/PostgreSQL).

## Testing & Verification
- Manually compared the production database schema (`heroku pg:psql`) with the codebase models and migrations.
- Verified that the production database currently contains `rating`, `consent`, and `experiment_session` tables, but is at an older migration version (`b7feb046b086`).
- This fix will allow the deployment process to skip creating tables that already exist, resolving the `DuplicateTable` error.

## Checklist
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration robustness by implementing conditional existence checks for database tables, columns, and foreign key constraints before creation operations, preventing failures and errors when migrations are applied to databases with pre-existing schemas, incomplete states, or executed multiple times during various deployment and operational scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->