### PR TITLE
feat(consent): IRB Section 8 disclosure + drop full_name PII

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -119,7 +119,6 @@ class Consent(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     session_id = db.Column(db.String(36), nullable=False, unique=True)
-    full_name = db.Column(db.String(255), nullable=False)
     experiment_group = db.Column(db.String(20), nullable=False)
     consented_at = db.Column(
         db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -110,7 +110,7 @@ def submit_consent():
 
     group = random.choice(["control", "experimental"])
 
-    consent = Consent(session_id=sid, full_name="", experiment_group=group)
+    consent = Consent(session_id=sid, experiment_group=group)
     exp_session = ExperimentSession(
         session_id=sid,
         experiment_group=group,

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -179,3 +179,211 @@ a.logout-btn:hover, a.logout-btn:focus, a.logout-btn:active {
     margin-left: 0;
     font-size: 0.9rem;
 }
+
+/* Consent page */
+.consent-hero-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 64px;
+    height: 64px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba(248, 205, 36, 0.2), rgba(248, 205, 36, 0.05));
+    border: 1px solid rgba(248, 205, 36, 0.3);
+    color: var(--th-yellow);
+    font-size: 1.75rem;
+}
+
+.consent-section {
+    scroll-margin-top: 80px;
+}
+
+.consent-section + .consent-section {
+    margin-top: 2.25rem;
+    padding-top: 2.25rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.consent-section-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.consent-section-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 34px;
+    height: 34px;
+    padding: 0 0.55rem;
+    border-radius: 999px;
+    background-color: rgba(248, 205, 36, 0.12);
+    color: var(--th-yellow);
+    font-weight: 700;
+    font-size: 0.9rem;
+    letter-spacing: 0.02em;
+    flex-shrink: 0;
+}
+
+.consent-section-title {
+    font-size: 1.15rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--th-text-main);
+}
+
+.consent-section p,
+.consent-section li {
+    color: #d5d7dc;
+    line-height: 1.65;
+}
+
+.consent-section a {
+    color: var(--th-yellow);
+    text-decoration: none;
+    word-break: break-word;
+}
+
+.consent-section a:hover {
+    text-decoration: underline;
+}
+
+.consent-team-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    margin-bottom: 0;
+    overflow: hidden;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.consent-team-table thead th {
+    background-color: rgba(255, 255, 255, 0.03);
+    color: var(--th-text-muted);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.consent-team-table tbody td {
+    padding: 0.75rem 1rem;
+    color: var(--th-text-main);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    font-size: 0.95rem;
+}
+
+.consent-team-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.consent-team-table tbody tr td:nth-child(2) {
+    color: var(--th-text-muted);
+}
+
+.consent-callout {
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background-color: rgba(255, 255, 255, 0.02);
+}
+
+.consent-callout-danger {
+    border-color: rgba(220, 53, 69, 0.35);
+    background-color: rgba(220, 53, 69, 0.06);
+}
+
+.consent-callout-success {
+    border-color: rgba(40, 167, 69, 0.35);
+    background-color: rgba(40, 167, 69, 0.06);
+}
+
+.consent-callout-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 700;
+    font-size: 0.95rem;
+    margin-bottom: 0.5rem;
+}
+
+.consent-callout-danger .consent-callout-heading {
+    color: #f28b94;
+}
+
+.consent-callout-success .consent-callout-heading {
+    color: #7bd98f;
+}
+
+.consent-callout ul {
+    margin-bottom: 0;
+    padding-left: 1.25rem;
+}
+
+.consent-callout ul li {
+    margin-bottom: 0.25rem;
+}
+
+.consent-callout ul li:last-child {
+    margin-bottom: 0;
+}
+
+.consent-important-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    border-radius: 12px;
+    background: linear-gradient(135deg, rgba(248, 205, 36, 0.08), rgba(248, 205, 36, 0.02));
+    border: 1px solid rgba(248, 205, 36, 0.25);
+    color: var(--th-text-main);
+}
+
+.consent-important-banner i {
+    color: var(--th-yellow);
+    font-size: 1.25rem;
+    margin-top: 0.15rem;
+}
+
+.consent-agreement-box {
+    position: sticky;
+    bottom: 1rem;
+    margin-top: 2.5rem;
+    padding: 1.5rem;
+    border-radius: 16px;
+    background: linear-gradient(180deg, rgba(34, 34, 36, 0.85), rgba(34, 34, 36, 0.95));
+    border: 1px solid rgba(248, 205, 36, 0.3);
+    backdrop-filter: blur(8px);
+    box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.consent-agreement-box .btn-primary:disabled {
+    background-color: rgba(248, 205, 36, 0.35) !important;
+    border-color: rgba(248, 205, 36, 0.35) !important;
+    color: rgba(0, 0, 0, 0.55) !important;
+    cursor: not-allowed;
+    opacity: 1;
+}
+
+.consent-footer-meta {
+    color: var(--th-text-muted);
+    font-size: 0.8rem;
+    text-align: center;
+    padding-top: 1.5rem;
+    margin-top: 2rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.consent-footer-meta a {
+    color: var(--th-text-muted);
+    text-decoration: underline;
+}
+
+.consent-footer-meta a:hover {
+    color: var(--th-yellow);
+}

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -243,7 +243,8 @@ a.logout-btn:hover, a.logout-btn:focus, a.logout-btn:active {
 .consent-section a {
     color: var(--th-yellow);
     text-decoration: none;
-    word-break: break-word;
+    overflow-wrap: anywhere;
+    word-break: normal;
 }
 
 .consent-section a:hover {

--- a/app/templates/consent.html
+++ b/app/templates/consent.html
@@ -12,23 +12,376 @@
 {% endblock %}
 
 {% block content %}
-<div class="container" style="max-width: 800px;">
+<div class="container" style="max-width: 820px;">
   <div class="bg-card rounded-4 border border-secondary border-opacity-25 p-4 p-md-5">
+
     <div class="text-center mb-4">
-      <h1 class="fw-bold mt-3 mb-1">Informed Consent Disclosure</h1>
+      <div class="consent-hero-icon mb-3">
+        <i class="bi bi-shield-check"></i>
+      </div>
+      <h1 class="fw-extrabold mb-2" style="font-size: 2rem;">Informed Consent Disclosure</h1>
       <p class="text-secondary mb-0">TrueHair AI Hairstyle Visualization Study</p>
+      <p class="text-secondary small mb-0"><em>Colby College — Department of Computer Science — CS422</em></p>
     </div>
 
-    <p class="text-secondary">
-      Placeholder consent page. The full IRB-approved disclosure text will be rendered here
-      as part of issue #4 (dedicated consent route). By proceeding, you agree to participate.
-    </p>
+    <div class="consent-important-banner mb-4">
+      <i class="bi bi-info-circle-fill"></i>
+      <div>
+        <div class="fw-bold mb-1">Please read carefully before participating</div>
+        <div class="text-secondary small mb-0">
+          This is an IRB-approved research study. Your participation is entirely voluntary.
+        </div>
+      </div>
+    </div>
 
-    <form method="POST" action="{{ url_for('main.submit_consent') }}" class="mt-4 pt-4 border-top border-secondary border-opacity-25">
-      <button type="submit" class="btn btn-primary fw-bold w-100 py-3 rounded-3">
-        I Agree — Begin Study
-      </button>
-    </form>
+    <section id="section-1" class="consent-section">
+      <div class="consent-section-heading">
+        <span class="consent-section-number">1</span>
+        <h2 class="consent-section-title">Purpose of This Research</h2>
+      </div>
+      <p>
+        You are being invited to participate in a research study conducted by
+        students in CS422 at Colby College, under the supervision of Prof. Naser
+        Al Madi. The purpose of this study is to investigate whether AI-powered
+        personalized hairstyle recommendations improve user engagement and
+        perceived output quality on the TrueHair AI platform compared to a
+        standard hairstyle catalog.
+      </p>
+      <p class="mb-0">
+        Participation is entirely voluntary. Please read this disclosure
+        carefully before deciding whether to participate.
+      </p>
+    </section>
+
+    <section id="section-2" class="consent-section">
+      <div class="consent-section-heading">
+        <span class="consent-section-number">2</span>
+        <h2 class="consent-section-title">Research Team</h2>
+      </div>
+      <div class="table-responsive mb-3">
+        <table class="consent-team-table">
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Role</th>
+              <th scope="col">Email</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Simon Lartey</td>
+              <td>Student Researcher</td>
+              <td><a href="mailto:slarte27@colby.edu">slarte27@colby.edu</a></td>
+            </tr>
+            <tr>
+              <td>Rose Agyapong</td>
+              <td>Student Researcher</td>
+              <td><a href="mailto:rfagya27@colby.edu">rfagya27@colby.edu</a></td>
+            </tr>
+            <tr>
+              <td>Samuel Offei</td>
+              <td>Student Researcher</td>
+              <td><a href="mailto:shoffe26@colby.edu">shoffe26@colby.edu</a></td>
+            </tr>
+            <tr>
+              <td>Francis O'Hara Aidoo</td>
+              <td>Student Researcher</td>
+              <td><a href="mailto:fohara27@colby.edu">fohara27@colby.edu</a></td>
+            </tr>
+            <tr>
+              <td>Prof. Naser Al Madi</td>
+              <td>Faculty Supervisor</td>
+              <td><a href="mailto:nsalmadi@colby.edu">nsalmadi@colby.edu</a></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="mb-0">
+        Questions? You may contact the research team at any time at the emails
+        above, or reach the Colby IRB at
+        <a href="mailto:institutionalreviewboard@colby.edu">institutionalreviewboard@colby.edu</a>.
+      </p>
+    </section>
+
+    <section id="section-3" class="consent-section">
+      <div class="consent-section-heading">
+        <span class="consent-section-number">3</span>
+        <h2 class="consent-section-title">What You Will Be Asked To Do</h2>
+      </div>
+      <p>If you agree to participate, you will:</p>
+      <ul>
+        <li>
+          Access the TrueHair AI web application at
+          <a href="https://truehair-ai-c77120f7a186.herokuapp.com/">https://truehair-ai-c77120f7a186.herokuapp.com/</a>.
+        </li>
+        <li>
+          Be randomly assigned to one of two study conditions:
+          <ul>
+            <li>a <strong>control group</strong> that browses a catalog of predefined hairstyles, or</li>
+            <li>an <strong>experimental group</strong> that receives AI-powered personalized hairstyle recommendations highlighted within the same full catalog, with AI-generated reasoning for each recommendation.</li>
+          </ul>
+        </li>
+        <li>Upload a front-facing portrait photograph of yourself for hairstyle visualization.</li>
+        <li>Generate one or more hairstyle visualizations using the interface available to your assigned group.</li>
+        <li>Rate each AI-generated visualization on a 1-5 star scale.</li>
+        <li>Complete the session at your own pace. Expected duration is approximately 10-15 minutes.</li>
+      </ul>
+      <p class="mb-0">
+        The platform will automatically record your session duration, the number
+        of visualizations you generate, the hairstyles you select, your star
+        ratings, and (for the experimental group) whether each hairstyle you
+        selected was AI-recommended. You will not be asked to complete any
+        additional surveys or interviews.
+      </p>
+    </section>
+
+    <section id="section-4" class="consent-section">
+      <div class="consent-section-heading">
+        <span class="consent-section-number">4</span>
+        <h2 class="consent-section-title">Information We Will and Will Not Collect</h2>
+      </div>
+      <p>
+        This is a fully anonymous research study. The research team will not
+        collect any personally identifiable information about you.
+      </p>
+
+      <div class="row g-3 mb-3">
+        <div class="col-md-6">
+          <div class="consent-callout consent-callout-danger h-100">
+            <div class="consent-callout-heading">
+              <i class="bi bi-x-circle-fill"></i>
+              Specifically, we will NOT collect
+            </div>
+            <ul>
+              <li>Your name</li>
+              <li>Your email address</li>
+              <li>Any account or login information</li>
+              <li>Your IP address (stripped from server logs)</li>
+              <li>Any persistent record of your photograph or generated visualizations</li>
+            </ul>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="consent-callout consent-callout-success h-100">
+            <div class="consent-callout-heading">
+              <i class="bi bi-check-circle-fill"></i>
+              We WILL record
+            </div>
+            <ul>
+              <li>An anonymous session identifier (a random code with no link to your identity)</li>
+              <li>Which experimental condition you were assigned to</li>
+              <li>Which hairstyles you visualized (catalog identifiers only), and whether each was AI-recommended (experimental group only)</li>
+              <li>Your 1-5 star ratings of each visualization</li>
+              <li>How long you spent on the platform</li>
+              <li>How many visualizations you generated</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <p class="mb-0">
+        Your photograph is required to generate the hairstyle visualization, but
+        it is processed in server memory only and is never saved to any
+        database, cloud storage, or log file. Once your visualization is
+        generated, your photograph and the generated image are immediately
+        discarded from the server.
+      </p>
+    </section>
+
+    <section id="section-5" class="consent-section">
+      <div class="consent-section-heading">
+        <span class="consent-section-number">5</span>
+        <h2 class="consent-section-title">Use of AI Technology and Third-Party Processing</h2>
+      </div>
+      <p>
+        This study uses Google's Gemini models via the Vertex AI API to
+        generate hairstyle visualizations and personalized recommendations from
+        your uploaded photograph. By participating, you acknowledge that your
+        photograph will be transmitted to Google's API servers for processing.
+        The following protections apply:
+      </p>
+      <ul>
+        <li>Google's paid-tier terms of service prohibit using API request data to train Google's AI models.</li>
+        <li>
+          Google retains API request data for up to 90 days for abuse monitoring
+          before automatic deletion (see Google Cloud's abuse monitoring
+          policy:
+          <a href="https://cloud.google.com/vertex-ai/generative-ai/docs/learn/abuse-monitoring">https://cloud.google.com/vertex-ai/generative-ai/docs/learn/abuse-monitoring</a>).
+          The research team has taken steps to achieve Zero Data Retention (ZDR)
+          as documented in Google Cloud's data governance policy
+          (<a href="https://cloud.google.com/vertex-ai/generative-ai/docs/data-governance">https://cloud.google.com/vertex-ai/generative-ai/docs/data-governance</a>):
+          <blockquote class="disclosure-blockquote mt-2 mb-2">
+            data caching has been disabled so your photo is not stored beyond the
+            immediate request, and an exception from prompt logging for abuse
+            monitoring has been applied for, which upon approval will ensure your
+            photo is not logged at all.
+          </blockquote>
+        </li>
+        <li>The API call carries no information about you (no name, no email, no account identifier). Google has no means of associating the photograph with you as an individual.</li>
+      </ul>
+      <p class="mb-0">
+        If you have concerns about Google's handling of API data, you can
+        review Google Cloud's data governance policy at
+        <a href="https://cloud.google.com/vertex-ai/generative-ai/docs/data-governance">https://cloud.google.com/vertex-ai/generative-ai/docs/data-governance</a>.
+      </p>
+    </section>
+
+    <section id="section-6" class="consent-section">
+      <div class="consent-section-heading">
+        <span class="consent-section-number">6</span>
+        <h2 class="consent-section-title">Potential Risks</h2>
+      </div>
+      <p>The risks associated with this study are minimal:</p>
+      <ul class="mb-0">
+        <li>Minor emotional discomfort related to self-image when viewing AI-generated visualizations of yourself with different hairstyles.</li>
+        <li>Minimal privacy considerations associated with briefly transmitting your photograph to Google's Vertex AI API. Mitigations are described in Section 5 above.</li>
+        <li>Please upload only photographs of yourself, or photographs of others for which you have explicit permission from the person depicted. Do not upload images of others without their consent.</li>
+      </ul>
+    </section>
+
+    <section id="section-7" class="consent-section">
+      <div class="consent-section-heading">
+        <span class="consent-section-number">7</span>
+        <h2 class="consent-section-title">Potential Benefits</h2>
+      </div>
+      <p class="mb-0">
+        You may personally benefit from exploring hairstyle options through the
+        platform. More broadly, this study contributes to research on AI
+        personalization and the design of human-centered AI systems. There is no
+        direct financial compensation for participation.
+      </p>
+    </section>
+
+    <section id="section-8" class="consent-section">
+      <div class="consent-section-heading">
+        <span class="consent-section-number">8</span>
+        <h2 class="consent-section-title">Voluntary Participation and Right to Withdraw</h2>
+      </div>
+      <p>
+        Your participation in this study is completely voluntary. You may
+        withdraw at any time during your session by simply closing the browser
+        window. No penalty or consequence will result from withdrawing.
+      </p>
+      <p class="mb-0">
+        Important: Because this study is fully anonymous and we collect no
+        information that could identify you, we cannot identify your specific
+        data within our records after your session ends. As a result, we are
+        unable to honor requests to delete data after the fact, because we have
+        no way to determine which records belong to you. If you do not wish your
+        data to be included in the study, please withdraw before completing the
+        session by closing the browser.
+      </p>
+    </section>
+
+    <section id="section-9" class="consent-section">
+      <div class="consent-section-heading">
+        <span class="consent-section-number">9</span>
+        <h2 class="consent-section-title">Confidentiality</h2>
+      </div>
+      <p class="mb-0">
+        Confidentiality is preserved by design: the research team has no
+        technical means to identify any participant. No identifying information
+        will appear in any published reports, presentations, or academic work,
+        because no identifying information has ever been collected. All
+        published findings will use anonymous, aggregate data only.
+      </p>
+    </section>
+
+    <section id="section-10" class="consent-section">
+      <div class="consent-section-heading">
+        <span class="consent-section-number">10</span>
+        <h2 class="consent-section-title">Eligibility</h2>
+      </div>
+      <p class="mb-0">
+        You are eligible to participate if you are 18 years of age or older.
+        This study does not restrict participation based on gender, race,
+        ethnicity, or any other demographic characteristic.
+      </p>
+    </section>
+
+    <section id="section-11" class="consent-section">
+      <div class="consent-section-heading">
+        <span class="consent-section-number">11</span>
+        <h2 class="consent-section-title">Agreement</h2>
+      </div>
+      <p>By clicking the "I agree" button on the platform, you confirm that:</p>
+      <ul>
+        <li>You have read and understood the information in this consent disclosure.</li>
+        <li>You are 18 years of age or older.</li>
+        <li>You voluntarily agree to participate in this research study.</li>
+        <li>You understand that your participation is voluntary and that you may withdraw at any time during the session by closing the browser.</li>
+        <li>You understand that because the study is anonymous, your data cannot be identified or removed after your session ends.</li>
+        <li>You have had the opportunity to ask questions before agreeing.</li>
+      </ul>
+      <p class="mb-0">
+        No name, signature, or email address is required to indicate your
+        agreement. Clicking "I agree" constitutes your consent.
+      </p>
+    </section>
+
+    <div id="consent-bottom-sentinel" aria-hidden="true"></div>
+
+    <div class="consent-agreement-box">
+      <form method="POST" action="{{ url_for('main.submit_consent') }}">
+        <button id="consent-agree-btn" type="submit" disabled aria-disabled="true"
+                class="btn btn-primary fw-bold w-100 py-3 rounded-3 d-flex align-items-center justify-content-center gap-2">
+          <i class="bi bi-check2-circle"></i>
+          <span class="consent-btn-label">I Agree — Begin Study</span>
+        </button>
+        <p id="consent-scroll-hint" class="text-secondary small text-center mt-3 mb-0">
+          <i class="bi bi-arrow-down-circle me-1"></i>
+          Please scroll to the end of the disclosure to enable this button.
+        </p>
+        <p id="consent-ready-hint" class="text-secondary small text-center mt-3 mb-0 d-none">
+          By clicking "I Agree," you confirm you have read the information above,
+          are 18 or older, and voluntarily consent to participate.
+        </p>
+      </form>
+    </div>
+
+    <div class="consent-footer-meta">
+      <p class="mb-1">
+        Colby College Institutional Review Board |
+        <a href="mailto:institutionalreviewboard@colby.edu">institutionalreviewboard@colby.edu</a>
+      </p>
+      <p class="mb-0">TrueHair AI Research Study — CS422 — Colby College — Spring 2026</p>
+    </div>
+
   </div>
 </div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+  (function () {
+    var btn = document.getElementById('consent-agree-btn');
+    var sentinel = document.getElementById('consent-bottom-sentinel');
+    var scrollHint = document.getElementById('consent-scroll-hint');
+    var readyHint = document.getElementById('consent-ready-hint');
+
+    if (!btn || !sentinel) return;
+
+    function unlock() {
+      btn.disabled = false;
+      btn.setAttribute('aria-disabled', 'false');
+      if (scrollHint) scrollHint.classList.add('d-none');
+      if (readyHint) readyHint.classList.remove('d-none');
+    }
+
+    if ('IntersectionObserver' in window) {
+      var observer = new IntersectionObserver(function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            unlock();
+            observer.disconnect();
+          }
+        });
+      }, { rootMargin: '0px 0px -10% 0px', threshold: 0 });
+      observer.observe(sentinel);
+    } else {
+      // Fallback: no IntersectionObserver — enable immediately
+      unlock();
+    }
+  })();
+</script>
 {% endblock %}

--- a/migrations/versions/d1e4f5a6b7c8_drop_consent_full_name.py
+++ b/migrations/versions/d1e4f5a6b7c8_drop_consent_full_name.py
@@ -1,0 +1,37 @@
+"""Drop full_name column from Consent (IRB Section 6.3 — PII minimization)
+
+Revision ID: d1e4f5a6b7c8
+Revises: c3a1d2b4e5f6
+Create Date: 2026-04-19 00:00:00.000000
+
+IRB Section 6.3 specifies that the consent record stores only (a) the anonymous
+session ID, (b) the experimental condition, and (c) the server-side consent
+timestamp. The legacy `full_name` column was PII that contradicted the approved
+protocol and is removed here.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "d1e4f5a6b7c8"
+down_revision = "c3a1d2b4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("consent") as batch_op:
+        batch_op.drop_column("full_name")
+
+
+def downgrade():
+    with op.batch_alter_table("consent") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "full_name",
+                sa.String(length=255),
+                nullable=False,
+                server_default="",
+            )
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,9 +53,7 @@ def _make_consented_session(app, experiment_group="control"):
     """Create a Consent + ExperimentSession row and return the session_id."""
     sid = str(uuid.uuid4())
     with app.app_context():
-        db.session.add(
-            Consent(session_id=sid, full_name="", experiment_group=experiment_group)
-        )
+        db.session.add(Consent(session_id=sid, experiment_group=experiment_group))
         db.session.add(
             ExperimentSession(
                 session_id=sid,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -20,9 +20,7 @@ def _consent_and_login(app, client, experiment_group="control"):
     """Helper: create a Consent + ExperimentSession and attach the session_id to client."""
     sid = str(uuid.uuid4())
     with app.app_context():
-        db.session.add(
-            Consent(session_id=sid, full_name="", experiment_group=experiment_group)
-        )
+        db.session.add(Consent(session_id=sid, experiment_group=experiment_group))
         db.session.add(
             ExperimentSession(
                 session_id=sid,


### PR DESCRIPTION
## Description
Two IRB-compliance changes that pair together. First, the `/consent` page now renders the verbatim Section 8 disclosure from the IRB application (all 11 sub-sections) so participants see the exact text the IRB reviewed, and the "I Agree" button is gated on scrolling to the end of the disclosure. Second, the legacy `full_name` column on the `Consent` model — which predated the anonymous-session migration and is no longer written by any code path — is dropped per IRB Section 6.3 (no directly identifiable information).

## Related Issues
Closes #51
Closes #52

## Changes Made
- [x] Render all 11 sub-sections of IRB Section 8 verbatim on `/consent` (Purpose through Agreement), including the research-team table and the ZDR policy blockquote
- [x] Style the consent page with a hero icon, numbered section badges, danger/success callouts for the collect / not-collect split, and a sticky agreement box
- [x] Disable the "I Agree" button until an IntersectionObserver sentinel at the end of the disclosure enters the viewport; swap the helper copy from a "scroll to the end" hint to a "ready to agree" hint
- [x] Remove `full_name` from the `Consent` model
- [x] Add Alembic migration `d1e4f5a6b7c8` to drop the `full_name` column
- [x] Drop `full_name=""` from the consent route and from the test fixtures

## Testing & Verification
- `uv run flask --app run db upgrade` applies migration `d1e4f5a6b7c8` cleanly on top of `c3a1d2b4e5f6`
- `uv run pytest` — 73 tests pass
- Manual `/consent` flow in a fresh session: page renders all 11 sections, the I Agree button is disabled with the "scroll to the end" hint; after scrolling past the final section the button enables and the hint swaps; submitting redirects into the app and persists a Consent row with no `full_name` column

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned consent page with detailed disclosure sections, team contact information, and study procedures
  * Added interactive agreement button that becomes enabled only after scrolling through the complete consent terms

* **Refactor**
  * Removed full_name requirement from consent submission

<!-- end of auto-generated comment: release notes by coderabbit.ai -->