### PR TITLE
Migrate genai client to Vertex AI for ZDR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 FLASK_SECRET_KEY=your-super-secret-key-here
-GEMINI_API_KEY=your-gemini-api-key
+GOOGLE_CLOUD_PROJECT=your-google-cloud-project-id
+GOOGLE_CLOUD_LOCATION=us-central1
+GOOGLE_APPLICATION_CREDENTIALS_JSON=base64-encoded-service-account-json
 R2_ACCOUNT_ID=your-r2-account-id
 R2_ACCESS_KEY_ID=your-r2-access-key-id
 R2_SECRET_ACCESS_KEY=your-r2-secret-access-key

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,6 @@
+import atexit
 import base64
+import binascii
 import json
 import os
 import tempfile
@@ -11,22 +13,41 @@ from config import Config
 
 migrate = Migrate()
 
+_creds_path = None
+
 
 def _setup_gcp_credentials():
     encoded = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
     if not encoded:
         return
 
+    global _creds_path
+    if _creds_path:
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = _creds_path
+        return
+
     try:
         key_json = base64.b64decode(encoded).decode("utf-8")
         json.loads(key_json)
-    except Exception:
-        raise RuntimeError("Invalid GOOGLE_APPLICATION_CREDENTIALS_JSON format")
+    except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            "Invalid GOOGLE_APPLICATION_CREDENTIALS_JSON format"
+        ) from exc
 
     fd, path = tempfile.mkstemp(suffix=".json")
     with os.fdopen(fd, "w") as f:
         f.write(key_json)
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = path
+    _creds_path = path
+
+    def _cleanup():
+        try:
+            if os.path.exists(path):
+                os.remove(path)
+        except OSError:
+            pass
+
+    atexit.register(_cleanup)
 
 
 def create_app(config_class=Config):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import os
 import tempfile
 
@@ -13,12 +14,19 @@ migrate = Migrate()
 
 def _setup_gcp_credentials():
     encoded = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
-    if encoded:
+    if not encoded:
+        return
+
+    try:
         key_json = base64.b64decode(encoded).decode("utf-8")
-        fd, path = tempfile.mkstemp(suffix=".json")
-        with os.fdopen(fd, "w") as f:
-            f.write(key_json)
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = path
+        json.loads(key_json)
+    except Exception:
+        raise RuntimeError("Invalid GOOGLE_APPLICATION_CREDENTIALS_JSON format")
+
+    fd, path = tempfile.mkstemp(suffix=".json")
+    with os.fdopen(fd, "w") as f:
+        f.write(key_json)
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = path
 
 
 def create_app(config_class=Config):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,7 +22,7 @@ def _setup_gcp_credentials():
         return
 
     global _creds_path
-    if _creds_path:
+    if _creds_path and os.path.exists(_creds_path):
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = _creds_path
         return
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,7 @@
+import base64
+import os
+import tempfile
+
 from flask import Flask
 from flask_migrate import Migrate
 
@@ -7,10 +11,22 @@ from config import Config
 migrate = Migrate()
 
 
+def _setup_gcp_credentials():
+    encoded = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+    if encoded:
+        key_json = base64.b64decode(encoded).decode("utf-8")
+        fd, path = tempfile.mkstemp(suffix=".json")
+        with os.fdopen(fd, "w") as f:
+            f.write(key_json)
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = path
+
+
 def create_app(config_class=Config):
     """Create and configure the Flask application factory."""
     app = Flask(__name__)
     app.config.from_object(config_class)
+
+    _setup_gcp_credentials()
 
     db.init_app(app)
     migrate.init_app(app, db)

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -50,11 +50,19 @@ def _day_of_week(date_column):
 
 
 def get_genai_client():
-    """Return a google.genai Client configured with the API key, or None."""
-    api_key = current_app.config.get("GEMINI_API_KEY")
-    if not api_key:
+    """Return a google.genai Client configured for Vertex AI (IRB-compliant, ZDR)."""
+    project = current_app.config.get("GOOGLE_CLOUD_PROJECT")
+    location = current_app.config.get("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+    if not project:
+        current_app.logger.error("GOOGLE_CLOUD_PROJECT is not set")
         return None
-    return genai.Client(api_key=api_key)
+
+    return genai.Client(
+        vertexai=True,
+        project=project,
+        location=location
+    )
 
 
 @main_bp.app_context_processor

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -606,7 +606,7 @@ Respond with a JSON object in this exact format:
 }}"""
 
         response = client.models.generate_content(
-            model="gemini-3-flash",
+            model="gemini-2.5-flash",
             contents=[prompt_text, user_photo],
             config=types.GenerateContentConfig(
                 response_mime_type="application/json",

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -58,11 +58,7 @@ def get_genai_client():
         current_app.logger.error("GOOGLE_CLOUD_PROJECT is not set")
         return None
 
-    return genai.Client(
-        vertexai=True,
-        project=project,
-        location=location
-    )
+    return genai.Client(vertexai=True, project=project, location=location)
 
 
 @main_bp.app_context_processor

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -50,7 +50,11 @@ def _day_of_week(date_column):
 
 
 def get_genai_client():
-    """Return a google.genai Client configured for Vertex AI (IRB-compliant, ZDR)."""
+    """Return a google.genai Client configured for Vertex AI.
+
+    Required by IRB Section 4.1 to ensure Zero Data Retention (ZDR).
+    Do not replace with Gemini Developer API.
+    """
     project = current_app.config.get("GOOGLE_CLOUD_PROJECT")
     location = current_app.config.get("GOOGLE_CLOUD_LOCATION", "us-central1")
 
@@ -602,7 +606,7 @@ Respond with a JSON object in this exact format:
 }}"""
 
         response = client.models.generate_content(
-            model="gemini-2.5-flash",
+            model="gemini-3-flash",
             contents=[prompt_text, user_photo],
             config=types.GenerateContentConfig(
                 response_mime_type="application/json",

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -58,7 +58,11 @@ def get_genai_client():
         current_app.logger.error("GOOGLE_CLOUD_PROJECT is not set")
         return None
 
-    return genai.Client(vertexai=True, project=project, location=location)
+    try:
+        return genai.Client(vertexai=True, project=project, location=location)
+    except Exception as e:
+        current_app.logger.error(f"Failed to initialize Vertex AI client: {e}")
+        return None
 
 
 @main_bp.app_context_processor

--- a/config.py
+++ b/config.py
@@ -22,7 +22,8 @@ class Config:
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SAMESITE = "Lax"
 
-    GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
+    GOOGLE_CLOUD_PROJECT = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    GOOGLE_CLOUD_LOCATION = os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
 
     R2_ACCOUNT_ID = os.environ.get("R2_ACCOUNT_ID")
     R2_ACCESS_KEY_ID = os.environ.get("R2_ACCESS_KEY_ID")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,8 @@ class TestConfig(Config):
     SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     WTF_CSRF_ENABLED = False
     SESSION_COOKIE_SECURE = False
-    GEMINI_API_KEY = "test-gemini-key"
+    GOOGLE_CLOUD_PROJECT = "test-project"
+    GOOGLE_CLOUD_LOCATION = "us-central1"
     R2_ACCOUNT_ID = "test-account-id"
     R2_ACCESS_KEY_ID = "test-access-key"
     R2_SECRET_ACCESS_KEY = "test-secret-key"

--- a/tests/test_app_init.py
+++ b/tests/test_app_init.py
@@ -1,0 +1,82 @@
+"""Tests for app initialization helpers."""
+
+import base64
+import json
+import os
+
+import pytest
+
+import app as app_module
+
+
+def _encode_credentials(payload):
+    return base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
+
+
+@pytest.fixture(autouse=True)
+def reset_gcp_credential_state(monkeypatch):
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    app_module._creds_path = None
+    yield
+    if app_module._creds_path and os.path.exists(app_module._creds_path):
+        os.remove(app_module._creds_path)
+    app_module._creds_path = None
+
+
+def test_setup_gcp_credentials_creates_file_and_registers_cleanup(monkeypatch):
+    payload = {
+        "type": "service_account",
+        "project_id": "test-project",
+        "private_key_id": "abc123",
+    }
+    key_json = json.dumps(payload)
+    monkeypatch.setenv(
+        "GOOGLE_APPLICATION_CREDENTIALS_JSON", _encode_credentials(payload)
+    )
+
+    cleanup_callbacks = []
+    monkeypatch.setattr(app_module.atexit, "register", cleanup_callbacks.append)
+
+    app_module._setup_gcp_credentials()
+
+    path = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+    assert app_module._creds_path == path
+    assert os.path.exists(path)
+    with open(path, "r", encoding="utf-8") as f:
+        assert f.read() == key_json
+
+    assert len(cleanup_callbacks) == 1
+    cleanup_callbacks[0]()
+    assert not os.path.exists(path)
+
+
+def test_setup_gcp_credentials_reuses_existing_temp_file(monkeypatch):
+    existing_path = "/tmp/existing-test-creds.json"
+    app_module._creds_path = existing_path
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "ignored-when-reusing")
+
+    mkstemp_called = {"called": False}
+
+    def _unexpected_mkstemp(*args, **kwargs):
+        mkstemp_called["called"] = True
+        raise AssertionError(
+            "mkstemp should not be called when reusing credential path"
+        )
+
+    monkeypatch.setattr(app_module.tempfile, "mkstemp", _unexpected_mkstemp)
+
+    app_module._setup_gcp_credentials()
+
+    assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == existing_path
+    assert mkstemp_called["called"] is False
+
+
+def test_setup_gcp_credentials_raises_on_invalid_payload(monkeypatch):
+    invalid_json = base64.b64encode(b"not-json").decode("utf-8")
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", invalid_json)
+
+    with pytest.raises(
+        RuntimeError, match="Invalid GOOGLE_APPLICATION_CREDENTIALS_JSON format"
+    ):
+        app_module._setup_gcp_credentials()

--- a/tests/test_app_init.py
+++ b/tests/test_app_init.py
@@ -51,9 +51,9 @@ def test_setup_gcp_credentials_creates_file_and_registers_cleanup(monkeypatch):
     assert not os.path.exists(path)
 
 
-def test_setup_gcp_credentials_reuses_existing_temp_file(monkeypatch):
-    existing_path = "/tmp/existing-test-creds.json"
-    app_module._creds_path = existing_path
+def test_setup_gcp_credentials_reuses_existing_temp_file(monkeypatch, tmp_path):
+    existing_path = tmp_path / "existing-test-creds.json"
+    app_module._creds_path = str(existing_path)
     monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "ignored-when-reusing")
 
     mkstemp_called = {"called": False}
@@ -68,7 +68,7 @@ def test_setup_gcp_credentials_reuses_existing_temp_file(monkeypatch):
 
     app_module._setup_gcp_credentials()
 
-    assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == existing_path
+    assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == str(existing_path)
     assert mkstemp_called["called"] is False
 
 

--- a/tests/test_app_init.py
+++ b/tests/test_app_init.py
@@ -53,8 +53,16 @@ def test_setup_gcp_credentials_creates_file_and_registers_cleanup(monkeypatch):
 
 def test_setup_gcp_credentials_reuses_existing_temp_file(monkeypatch, tmp_path):
     existing_path = tmp_path / "existing-test-creds.json"
+    existing_path.write_text('{"type": "service_account"}', encoding="utf-8")
     app_module._creds_path = str(existing_path)
-    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "ignored-when-reusing")
+    payload = {
+        "type": "service_account",
+        "project_id": "test-project",
+        "private_key_id": "abc123",
+    }
+    monkeypatch.setenv(
+        "GOOGLE_APPLICATION_CREDENTIALS_JSON", _encode_credentials(payload)
+    )
 
     mkstemp_called = {"called": False}
 
@@ -70,6 +78,28 @@ def test_setup_gcp_credentials_reuses_existing_temp_file(monkeypatch, tmp_path):
 
     assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == str(existing_path)
     assert mkstemp_called["called"] is False
+
+
+def test_setup_gcp_credentials_recreates_when_cached_path_is_missing(
+    monkeypatch, tmp_path
+):
+    missing_path = tmp_path / "missing-test-creds.json"
+    app_module._creds_path = str(missing_path)
+    payload = {
+        "type": "service_account",
+        "project_id": "test-project",
+        "private_key_id": "abc123",
+    }
+    monkeypatch.setenv(
+        "GOOGLE_APPLICATION_CREDENTIALS_JSON", _encode_credentials(payload)
+    )
+
+    app_module._setup_gcp_credentials()
+
+    new_path = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+    assert new_path != str(missing_path)
+    assert os.path.exists(new_path)
+    assert app_module._creds_path == new_path
 
 
 def test_setup_gcp_credentials_raises_on_invalid_payload(monkeypatch):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -63,6 +63,18 @@ def test_get_genai_client_returns_none_if_no_project(app):
     assert client is None
 
 
+def test_get_genai_client_returns_none_on_client_init_error(app):
+    """get_genai_client returns None when client initialization raises."""
+    with app.app_context():
+        app.config["GOOGLE_CLOUD_PROJECT"] = "test-project"
+        app.config["GOOGLE_CLOUD_LOCATION"] = "us-central1"
+
+        with patch("app.routes.main.genai.Client", side_effect=Exception("boom")):
+            client = get_genai_client()
+
+    assert client is None
+
+
 # ---------------------------------------------------------------------------
 # Index / consent gating
 # ---------------------------------------------------------------------------

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from PIL import Image
 
+from app.routes.main import get_genai_client
 from app.models import (
     Consent,
     ExperimentSession,
@@ -33,6 +34,33 @@ def _consent_and_login(app, client, experiment_group="control"):
     with client.session_transaction() as sess:
         sess["session_id"] = sid
     return sid
+
+
+def test_get_genai_client_uses_vertex_ai_config(app):
+    """get_genai_client configures Vertex AI using the Flask app config."""
+    with app.app_context():
+        app.config["GOOGLE_CLOUD_PROJECT"] = "test-project"
+        app.config["GOOGLE_CLOUD_LOCATION"] = "europe-west4"
+
+        with patch("app.routes.main.genai.Client") as mock_client:
+            client = get_genai_client()
+
+            mock_client.assert_called_once_with(
+                vertexai=True,
+                project="test-project",
+                location="europe-west4",
+            )
+            assert client is mock_client.return_value
+
+
+def test_get_genai_client_returns_none_if_no_project(app):
+    """get_genai_client returns None when the project is missing."""
+    with app.app_context():
+        app.config["GOOGLE_CLOUD_PROJECT"] = None
+
+        client = get_genai_client()
+
+    assert client is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
This PR migrates the Gemini client from API key-based authentication to Vertex AI in order to support Zero Data Retention (ZDR) as required by the IRB. This ensures that all model interactions are routed through Vertex AI where data retention settings can be controlled.

## Related Issues
Closes #56 

## Changes Made
- [x] Replaced `GEMINI_API_KEY` configuration with `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`
- [x] Updated `get_genai_client()` to initialize the client using Vertex AI (`vertexai=True`)
- [x] Added a credentials loader to support service account authentication via environment variables
- [x] Added a unit test to verify that `get_genai_client()` correctly configures the Vertex AI client
- [x] Applied Ruff linting and formatting

## Testing & Verification
- Verified that `get_genai_client()` initializes `genai.Client` with the correct Vertex AI configuration using a mocked test
- Ran all tests locally using `pytest` to ensure no regressions
- Ran linting and formatting using `uv run ruff check .` and `uv run ruff format .`
- Confirmed no remaining references to `GEMINI_API_KEY` in the codebase

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Environment template updated to use Google Cloud variables: project, location (defaults to us-central1), and base64 JSON credentials.
  * App startup now reads credentials from the environment, creates/uses a temporary credentials file (cached and cleaned on exit), and logs clearer errors when project config is missing.

* **Tests**
  * Added tests covering client initialization, missing-project behavior, credential loading, reuse, and invalid-credentials error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->