### PR TITLE
fix(migrations): remove duplicate visit.session_id add in f0e2aaf0c2c7

### DIFF
--- a/migrations/versions/f0e2aaf0c2c7_refactor_image_pipeline_remove_.py
+++ b/migrations/versions/f0e2aaf0c2c7_refactor_image_pipeline_remove_.py
@@ -1,4 +1,4 @@
-"""Refactor image pipeline: remove UserImage, drop image references, add session_id to Visit
+"""Refactor image pipeline: remove UserImage, drop image references
 
 Revision ID: f0e2aaf0c2c7
 Revises: d1e4f5a6b7c8
@@ -37,16 +37,8 @@ def upgrade():
 
     op.drop_table("user_image")
 
-    with op.batch_alter_table("visit", schema=None) as batch_op:
-        batch_op.add_column(
-            sa.Column("session_id", sa.String(length=36), nullable=True)
-        )
-
 
 def downgrade():
-    with op.batch_alter_table("visit", schema=None) as batch_op:
-        batch_op.drop_column("session_id")
-
     op.create_table(
         "user_image",
         sa.Column("id", sa.INTEGER(), nullable=False),


### PR DESCRIPTION
## Description
Heroku release command has been failing on the last two deploys (v59, v60), blocking production. The Alembic upgrade aborts in `f0e2aaf0c2c7_refactor_image_pipeline_remove_` with `DuplicateColumn: column "session_id" of relation "visit" already exists`. The earlier IRB migration `c3a1d2b4e5f6_irb_anonymous_identity` already added `visit.session_id`, so the second `add_column` call here is a spurious autogen artifact. This PR removes it.

## Related Issues
Closes #72

## Changes Made
- [x] Drop the `add_column("session_id")` block on `visit` from `f0e2aaf0c2c7.upgrade()`
- [x] Drop the matching `drop_column("session_id")` block from `f0e2aaf0c2c7.downgrade()`
- [x] Update migration docstring title to reflect the actual scope (no longer adds `session_id`)

## Testing & Verification
- Confirmed prod DB schema: `visit.session_id VARCHAR(36)` already exists.
- Confirmed prod `alembic_version = d1e4f5a6b7c8` (the `down_revision` of `f0e2aaf0c2c7`), so the remaining ops in this migration (drops on `generated_image` / `recommendation` / `user_image`) are still pending and will run as expected after the merge.
- Pre-commit hooks (ruff + ruff format) pass locally.
- On merge, Heroku should replay the release command and apply `f0e2aaf0c2c7` successfully.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated database migration to simplify schema modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->