### PR TITLE
feat(result): hydrate generated image from sessionStorage (#54)

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -469,7 +469,13 @@ def export_data():
 @main_bp.route("/result/<int:image_id>")
 @consent_required
 def result(image_id=None):
-    """Render the result of an AI hairstyle generation."""
+    """Render the result page for an AI hairstyle generation.
+
+    The generated image bytes are never persisted server-side (IRB Section 6.1);
+    the client holds the only copy in sessionStorage after /api/generate streams
+    the WebP back. This view renders metadata only (hairstyle name, rating state);
+    the template hydrates the <img> src from sessionStorage on load.
+    """
     log_visit("Results Page")
     sid = get_session_id()
     if image_id:
@@ -490,11 +496,7 @@ def result(image_id=None):
             .first()
         )
 
-    image_display_url = None
-
-    return render_template(
-        "result.html", latest_gen=gen_img, image_display_url=image_display_url
-    )
+    return render_template("result.html", latest_gen=gen_img)
 
 
 @main_bp.route("/gallery")

--- a/app/templates/result.html
+++ b/app/templates/result.html
@@ -27,13 +27,10 @@
             <!-- Image Card -->
             <div class="position-relative rounded-4 overflow-hidden border border-secondary border-opacity-25 shadow"
                 style="background-color: #1c1c1e;">
-                {% if latest_gen and image_display_url %}
-                <img src="{{ image_display_url }}" class="img-fluid w-100"
+                <img id="result-image"
+                    src="{{ url_for('static', filename='images/classic-fade-result.png') }}"
+                    class="img-fluid w-100"
                     style="object-fit: cover; aspect-ratio: 16/10;" alt="Generated Profile">
-                {% else %}
-                <img src="{{ url_for('static', filename='images/classic-fade-result.png') }}" class="img-fluid w-100"
-                    style="object-fit: cover; aspect-ratio: 16/10;" alt="Generated Profile">
-                {% endif %}
 
                 <!-- Fullscreen Overlay Button -->
                 <button type="button" class="btn btn-dark border-secondary border-opacity-50 text-white position-absolute bottom-0 end-0 m-3 rounded-circle"
@@ -82,20 +79,13 @@
                     style="background-color: #2a2a2d;" onclick="window.location.href='{{ url_for('main.gallery') }}';">
                     <i class="bi bi-images text-secondary"></i> My Gallery
                 </button>
-                {% if latest_gen and image_display_url %}
-                <a href="{{ image_display_url }}"
-                    download="truehair_{{ latest_gen.hairstyle.name | replace(' ', '_') }}_{{ latest_gen.id }}.webp"
-                    class="btn btn-dark border border-secondary border-opacity-50 rounded-3 d-flex align-items-center justify-content-center px-4 py-3"
-                    style="background-color: #2a2a2d;" title="Download Result">
+                <a id="result-download"
+                    href="#"
+                    {% if latest_gen %}data-download-filename="truehair_{{ latest_gen.hairstyle.name | replace(' ', '_') }}_{{ latest_gen.id }}.webp"{% endif %}
+                    class="btn btn-dark border border-secondary border-opacity-50 rounded-3 d-flex align-items-center justify-content-center px-4 py-3 opacity-50 pointer-events-none"
+                    style="background-color: #2a2a2d;" title="Download Result" aria-disabled="true">
                     <i class="bi bi-download text-white fs-5"></i>
                 </a>
-                {% else %}
-                <button
-                    class="btn btn-dark border border-secondary border-opacity-50 rounded-3 d-flex align-items-center justify-content-center px-4 py-3 opacity-50 pointer-events-none"
-                    style="background-color: #2a2a2d;" disabled>
-                    <i class="bi bi-download text-white fs-5"></i>
-                </button>
-                {% endif %}
                 <button
                     class="btn btn-dark border border-secondary border-opacity-50 rounded-3 d-flex align-items-center justify-content-center px-4 py-3 opacity-50"
                     style="background-color: #2a2a2d; cursor: not-allowed;" disabled title="Sharing coming soon">
@@ -162,11 +152,10 @@
                     </button>
                 </div>
                 <div class="modal-body text-center p-0 d-flex justify-content-center align-items-center">
-                    {% if latest_gen and image_display_url %}
-                    <img src="{{ image_display_url }}" class="img-fluid rounded-4 shadow-lg" alt="Generated Profile Fullscreen" style="max-height: 90vh; object-fit: contain; cursor: default;">
-                    {% else %}
-                    <img src="{{ url_for('static', filename='images/classic-fade-result.png') }}" class="img-fluid rounded-4 shadow-lg" alt="Generated Profile Fullscreen" style="max-height: 90vh; object-fit: contain; cursor: default;">
-                    {% endif %}
+                    <img id="result-image-modal"
+                        src="{{ url_for('static', filename='images/classic-fade-result.png') }}"
+                        class="img-fluid rounded-4 shadow-lg" alt="Generated Profile Fullscreen"
+                        style="max-height: 90vh; object-fit: contain; cursor: default;">
                 </div>
             </div>
         </div>
@@ -188,6 +177,32 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 });
+</script>
+<script>
+// Hydrate the result image from sessionStorage. The generated WebP is never
+// persisted server-side (IRB Section 6.1); the client holds the only copy.
+(function () {
+    var dataUrl = sessionStorage.getItem('generated_image');
+    var storedId = sessionStorage.getItem('generated_image_id');
+    if (!dataUrl) return;
+
+    var expectedId = {{ latest_gen.id if latest_gen else 'null' }};
+    if (expectedId !== null && storedId && String(expectedId) !== String(storedId)) return;
+
+    var img = document.getElementById('result-image');
+    var modalImg = document.getElementById('result-image-modal');
+    if (img) img.src = dataUrl;
+    if (modalImg) modalImg.src = dataUrl;
+
+    var download = document.getElementById('result-download');
+    if (download) {
+        download.href = dataUrl;
+        var filename = download.getAttribute('data-download-filename');
+        if (filename) download.setAttribute('download', filename);
+        download.classList.remove('opacity-50', 'pointer-events-none');
+        download.removeAttribute('aria-disabled');
+    }
+})();
 </script>
 {% if latest_gen %}
 <script>


### PR DESCRIPTION
## Description

IRB Sections 6.1 and 6.5 forbid server-side persistence of AI-generated hairstyle visualizations — they must be streamed to the participant's browser and never written to storage. #53 already removed the R2 upload path and dropped the `GeneratedImage.image_url` column, but `/result` was still passing `image_display_url=None`, so users saw the static `classic-fade-result.png` placeholder instead of their actual generated image. This PR closes that user-visible gap by hydrating the result page from the base64 data URL that `style_studio` already writes to `sessionStorage`.

## Related Issues

Closes #54

## Changes Made

- [x] Remove `{% if latest_gen and image_display_url %}` branches in `app/templates/result.html`; add stable ids (`result-image`, `result-image-modal`, `result-download`) to the main image, modal image, and download link.
- [x] Add a `DOMContentLoaded` script that reads `sessionStorage.generated_image` (+ `generated_image_id`) and, when the stored id matches `latest_gen.id` (or `latest_gen` is absent), sets the image `src`, sets the download `href` + filename, and removes the `opacity-50` / `pointer-events-none` disabled state. Falls back to placeholder otherwise.
- [x] Drop `image_display_url` from `result()` in `app/routes/main.py` and update the docstring to note the image bytes live only in client-side sessionStorage per IRB Section 6.1.

### Explicitly deferred (per plan discussion)

- `/result` and `/result/<int:image_id>` route deletion — blocked on #57 (SPA rewrite). Deletion makes sense only once the result view lives inline in the Style Studio SPA.
- R2 teardown (`app/services/r2.py`, `boto3` dep, `R2_*` env vars, `tests/test_r2_service.py`) — belongs to the #55 follow-up per the issue body. `r2.py` already has zero production callers; leaving it until gallery is deleted avoids scope creep.

## Testing & Verification

**Automated:** `uv run pytest` — 57/57 passing.

**Manual (preview dev server at `:8000`):**
1. Complete consent → land on `/style-studio`.
2. Seed `sessionStorage.generated_image` with a WebP data URL + matching `generated_image_id`, navigate to `/result`:
   - Main `<img>` `src` swaps to the data URL ✅
   - Modal `<img>` `src` swaps to the data URL ✅
   - Download `<a>` `href` + `download` filename set, disabled classes removed ✅
3. Clear sessionStorage, reload `/result`:
   - Placeholder image stays ✅
   - Download button remains disabled (`opacity-50 pointer-events-none`, `aria-disabled="true"`) ✅
4. DevTools: zero console errors, zero failed network requests, `/result` returns 200.

**IRB invariant:** no `r2_service.upload_bytes` / `make_generated_key` call sites remain (already verified in #53). This PR adds no new server-side writes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works — existing tests cover the route + rating flow; the template change is UI-verified above. No regressions (57/57 pass).
- [x] My code follows the style guidelines of this project — `ruff` + `ruff format` pre-commit hooks pass.
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Modified how generated images are retrieved and displayed, now loading them from your browser's session storage
* Download functionality remains available and unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->