### PR TITLE
fix(migrations): guard FK drops for SQLite in f0e2aaf0c2c7

### DIFF
--- a/migrations/versions/f0e2aaf0c2c7_refactor_image_pipeline_remove_.py
+++ b/migrations/versions/f0e2aaf0c2c7_refactor_image_pipeline_remove_.py
@@ -18,21 +18,28 @@ depends_on = None
 
 
 def upgrade():
+    # SQLite doesn't name FK constraints in the baseline schema, so drop_constraint
+    # fails. On SQLite, batch_alter_table recreates the table and FKs to dropped
+    # columns are discarded automatically.
+    is_sqlite = op.get_bind().dialect.name == "sqlite"
+
     with op.batch_alter_table("generated_image", schema=None) as batch_op:
-        batch_op.drop_constraint(
-            "fk_generated_image_reference_image_id", type_="foreignkey"
-        )
-        batch_op.drop_constraint(
-            "generated_image_user_image_id_fkey", type_="foreignkey"
-        )
+        if not is_sqlite:
+            batch_op.drop_constraint(
+                "fk_generated_image_reference_image_id", type_="foreignkey"
+            )
+            batch_op.drop_constraint(
+                "generated_image_user_image_id_fkey", type_="foreignkey"
+            )
         batch_op.drop_column("image_url")
         batch_op.drop_column("user_image_id")
         batch_op.drop_column("reference_image_id")
 
     with op.batch_alter_table("recommendation", schema=None) as batch_op:
-        batch_op.drop_constraint(
-            "recommendation_user_image_id_fkey", type_="foreignkey"
-        )
+        if not is_sqlite:
+            batch_op.drop_constraint(
+                "recommendation_user_image_id_fkey", type_="foreignkey"
+            )
         batch_op.drop_column("user_image_id")
 
     op.drop_table("user_image")


### PR DESCRIPTION
## Description
`f0e2aaf0c2c7` (refactor image pipeline) calls `drop_constraint` by name on FKs that SQLite's baseline schema doesn't explicitly name, so `flask db upgrade` fails locally with `ValueError: No such constraint: 'generated_image_user_image_id_fkey'`. This guards those drops behind a dialect check so SQLite dev DBs can upgrade cleanly while Postgres behavior is unchanged.

## Related Issues
Fixes #78

## Changes Made
- [x] Detect SQLite dialect in `upgrade()` and skip the named `drop_constraint` calls on SQLite (batch_alter_table drops FKs to removed columns automatically on table recreation)
- [x] Preserve existing explicit `drop_constraint` behavior on Postgres and other named-FK dialects

## Testing & Verification
- `flask db upgrade` against a fresh SQLite DB now runs through `f0e2aaf0c2c7` without the `No such constraint` error.
- Postgres path is unchanged — the named drops still execute when dialect != sqlite. Not verified locally (no Postgres), but the conditional is purely additive.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings