### PR TITLE
fix(logging): strip client IPs from gunicorn and Flask logs (#62)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn run:app
+web: gunicorn run:app --timeout 120 --access-logformat '%(m)s %(U)s %(s)s %(b)s %(L)s %({x-request-id}i)s'
 release: flask db upgrade && python seed_hairstyles.py && python seed_stylists.py

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # truehair-ai
 An AI-powered hairstyle visualization platform that helps users to explore hairstyles and connect with local stylists.
+
+## IRB compliance — logging
+
+Per IRB sections 2.1 and 6.5, client IP addresses must be stripped from application and infrastructure logs. This is implemented at two layers:
+
+- **Gunicorn access logs**: `Procfile` sets a custom `--access-logformat` that omits `%(h)s` (remote host). Only HTTP method, path, status, response size, latency, and the Heroku `X-Request-Id` correlation ID are logged.
+- **Flask / WSGI**: `app/__init__.py` wraps the WSGI app in `werkzeug.middleware.proxy_fix.ProxyFix(..., x_for=0, x_proto=1, x_host=1)`. With `x_for=0`, Flask ignores the `X-Forwarded-For` header, so `request.remote_addr` resolves to Heroku's internal router IP rather than the client's public IP. `x_proto` and `x_host` remain enabled so HTTPS and host detection still work for `url_for(..., _external=True)`.
+- **Request bodies**: no code path passes `request.data`, `request.files`, `request.form`, or `request.get_json()` into a logger. Error handlers log only exception messages and stack traces.
+
+### Known limitation — Heroku router logs
+
+Heroku's own router logs (emitted by `heroku[router]`) include the client IP in the `fwd=` field, and this cannot be stripped at that layer without a custom log drain. Mitigations:
+
+- Heroku log retention is ~1 week without a logging addon.
+- These logs are used only for operational debugging and are not queried by the research team as part of any analysis.
+
+This nuance should be surfaced to the IRB contact if further clarification is required.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,6 +7,7 @@ import tempfile
 
 from flask import Flask
 from flask_migrate import Migrate
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from app.models import db
 from config import Config
@@ -59,6 +60,12 @@ def create_app(config_class=Config):
 
     db.init_app(app)
     migrate.init_app(app, db)
+
+    # IRB compliance (sections 2.1 and 6.5): do not trust X-Forwarded-For for
+    # client IP. With x_for=0, request.remote_addr resolves to Heroku's internal
+    # router IP rather than the client's public IP. x_proto and x_host are kept
+    # so HTTPS and host detection still work for url_for(..., _external=True).
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=0, x_proto=1, x_host=1)
 
     from app.routes.main import main_bp
 

--- a/tests/test_app_init.py
+++ b/tests/test_app_init.py
@@ -5,8 +5,11 @@ import json
 import os
 
 import pytest
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 import app as app_module
+from app import create_app
+from tests.conftest import TestConfig
 
 
 def _encode_credentials(payload):
@@ -110,3 +113,18 @@ def test_setup_gcp_credentials_raises_on_invalid_payload(monkeypatch):
         RuntimeError, match="Invalid GOOGLE_APPLICATION_CREDENTIALS_JSON format"
     ):
         app_module._setup_gcp_credentials()
+
+
+def test_create_app_wraps_wsgi_in_proxyfix_with_x_for_zero():
+    """IRB compliance (sections 2.1, 6.5): X-Forwarded-For must not be trusted.
+
+    With x_for=0, request.remote_addr resolves to Heroku's internal router IP
+    rather than the client's public IP. This test locks in the invariant so a
+    future refactor cannot silently re-enable X-Forwarded-For trust.
+    """
+    app = create_app(TestConfig)
+
+    assert isinstance(app.wsgi_app, ProxyFix)
+    assert app.wsgi_app.x_for == 0
+    assert app.wsgi_app.x_proto == 1
+    assert app.wsgi_app.x_host == 1


### PR DESCRIPTION
## Summary
- Custom gunicorn `--access-logformat` in `Procfile` omits `%(h)s` (remote host); retains method, path, status, size, latency, and `X-Request-Id` for correlation. Also makes `--timeout 120` explicit.
- Wrap WSGI app in `ProxyFix(x_for=0, x_proto=1, x_host=1)` so `request.remote_addr` resolves to Heroku's internal router IP, not the client's. `x_proto`/`x_host` stay enabled so HTTPS detection and `url_for(..., _external=True)` keep working.
- Test in `tests/test_app_init.py` locks in the `x_for=0` invariant against future refactors.
- README documents the Heroku router-log `fwd=` limitation, which can't be stripped at our layer.

Closes #62.

## Test plan
- [ ] `pytest tests/test_app_init.py` passes locally
- [ ] After deploy, `heroku logs --tail` shows the new access-log format with no client IPs in app logs
- [ ] Spot-check a `url_for(..., _external=True)` call still produces an HTTPS URL with the correct host (ProxyFix `x_proto`/`x_host` regression check)
- [ ] Confirm with Naser/IRB contact that the Heroku router `fwd=` limitation documented in README is acceptable