### PR TITLE
fix(logging): strip client IPs from gunicorn and Flask logs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn run:app
+web: gunicorn run:app --timeout 120 --access-logformat '%(m)s %(U)s %(s)s %(b)s %(L)s %({x-request-id}i)s'
 release: flask db upgrade && python seed_hairstyles.py && python seed_stylists.py

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # truehair-ai
 An AI-powered hairstyle visualization platform that helps users to explore hairstyles and connect with local stylists.
+
+## IRB compliance — logging
+
+Per IRB sections 2.1 and 6.5, client IP addresses must be stripped from application and infrastructure logs. This is implemented at two layers:
+
+- **Gunicorn access logs**: `Procfile` sets a custom `--access-logformat` that omits `%(h)s` (remote host). Only HTTP method, path, status, response size, latency, and the Heroku `X-Request-Id` correlation ID are logged.
+- **Flask / WSGI**: `app/__init__.py` wraps the WSGI app in `werkzeug.middleware.proxy_fix.ProxyFix(..., x_for=0, x_proto=1, x_host=1)`. With `x_for=0`, Flask ignores the `X-Forwarded-For` header, so `request.remote_addr` resolves to Heroku's internal router IP rather than the client's public IP. `x_proto` and `x_host` remain enabled so HTTPS and host detection still work for `url_for(..., _external=True)`.
+- **Request bodies**: no code path passes `request.data`, `request.files`, `request.form`, or `request.get_json()` into a logger. Error handlers log only exception messages and stack traces.
+
+### Known limitation — Heroku router logs
+
+Heroku's own router logs (emitted by `heroku[router]`) include the client IP in the `fwd=` field, and this cannot be stripped at that layer without a custom log drain. Mitigations:
+
+- Heroku log retention is ~1 week without a logging addon.
+- These logs are used only for operational debugging and are not queried by the research team as part of any analysis.
+
+This nuance should be surfaced to the IRB contact if further clarification is required.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,6 +7,7 @@ import tempfile
 
 from flask import Flask
 from flask_migrate import Migrate
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from app.models import db
 from config import Config
@@ -59,6 +60,12 @@ def create_app(config_class=Config):
 
     db.init_app(app)
     migrate.init_app(app, db)
+
+    # IRB compliance (sections 2.1 and 6.5): do not trust X-Forwarded-For for
+    # client IP. With x_for=0, request.remote_addr resolves to Heroku's internal
+    # router IP rather than the client's public IP. x_proto and x_host are kept
+    # so HTTPS and host detection still work for url_for(..., _external=True).
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=0, x_proto=1, x_host=1)
 
     from app.routes.main import main_bp
 

--- a/tests/test_app_init.py
+++ b/tests/test_app_init.py
@@ -5,8 +5,11 @@ import json
 import os
 
 import pytest
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 import app as app_module
+from app import create_app
+from tests.conftest import TestConfig
 
 
 def _encode_credentials(payload):
@@ -110,3 +113,18 @@ def test_setup_gcp_credentials_raises_on_invalid_payload(monkeypatch):
         RuntimeError, match="Invalid GOOGLE_APPLICATION_CREDENTIALS_JSON format"
     ):
         app_module._setup_gcp_credentials()
+
+
+def test_create_app_wraps_wsgi_in_proxyfix_with_x_for_zero():
+    """IRB compliance (sections 2.1, 6.5): X-Forwarded-For must not be trusted.
+
+    With x_for=0, request.remote_addr resolves to Heroku's internal router IP
+    rather than the client's public IP. This test locks in the invariant so a
+    future refactor cannot silently re-enable X-Forwarded-For trust.
+    """
+    app = create_app(TestConfig)
+
+    assert isinstance(app.wsgi_app, ProxyFix)
+    assert app.wsgi_app.x_for == 0
+    assert app.wsgi_app.x_proto == 1
+    assert app.wsgi_app.x_host == 1


### PR DESCRIPTION
## Description
IRB sections 2.1 and 6.5 require client IP addresses to be stripped from application and infrastructure logs. Currently neither gunicorn's access log nor Flask's `request.remote_addr` are configured for this. This PR fixes both at the application layer and documents the one remaining gap (Heroku router logs) that can't be fixed without additional infra.

## Related Issues
Closes #62

## Changes Made
- [x] `Procfile`: set custom gunicorn `--access-logformat` that omits `%(h)s` (remote host); retains method, path, status, response size, latency, and `X-Request-Id` for correlation
- [x] `Procfile`: make `--timeout 120` explicit (was previously implicit; folded in here per the issue note about Gemini latency)
- [x] `app/__init__.py`: wrap WSGI app in `ProxyFix(x_for=0, x_proto=1, x_host=1)` so `request.remote_addr` resolves to Heroku's internal router IP rather than the client's; `x_proto`/`x_host` stay enabled so HTTPS detection and `url_for(..., _external=True)` keep working
- [x] `tests/test_app_init.py`: regression test that locks in `x_for=0` so a future refactor can't silently re-enable `X-Forwarded-For` trust
- [x] `README.md`: document the Heroku router-log `fwd=` limitation and recommended mitigations

## Testing & Verification
- `pytest tests/test_app_init.py` — new `test_create_app_wraps_wsgi_in_proxyfix_with_x_for_zero` passes; existing tests still pass
- Code-review pass with `grep -rn 'request\.\(data\|files\|form\|get_json\)' app/` confirms no request-body data is passed to a logger; existing logger calls in `app/routes/main.py` only emit exception messages and IDs
- Post-deploy verification (to do on the deploy PR): `heroku logs --tail` should show the new access-log format with no client IPs in app logs
- Manual smoke check: a `url_for(..., _external=True)` call should still produce an HTTPS URL with the correct host (regression check that `x_proto`/`x_host` are still active under `ProxyFix`)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added documentation on client IP handling and access log configuration.

* **Chores**
  * Updated Gunicorn runtime configuration with extended timeout and enhanced access log format including request metadata and trace headers.
  * Modified request proxy handling middleware.

* **Tests**
  * Added test coverage for request proxy middleware configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->