### PR TITLE
Feature: implement admin oauth dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,10 @@ R2_ACCOUNT_ID=your-r2-account-id
 R2_ACCESS_KEY_ID=your-r2-access-key-id
 R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
 R2_BUCKET_NAME=your-r2-bucket-name
+
+# Admin dashboard OAuth gate (issue #63).
+# Comma-separated list of Google email addresses allowed to access /dashboard
+# and /api/admin/export. Leave empty to disable admin access entirely.
+ADMIN_EMAILS=admin1@example.com,admin2@example.com
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,11 @@ R2_BUCKET_NAME=your-r2-bucket-name
 ADMIN_EMAILS=admin1@example.com,admin2@example.com
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
+
+# Google returns canonicalized scopes ("openid https://www.googleapis.com/
+# auth/userinfo.email") that differ from what we request ("email"). Required
+# in every environment so oauthlib does not reject the token exchange.
+OAUTHLIB_RELAX_TOKEN_SCOPE=1
+
+# Dev-only: allow OAuth over http://localhost. Do NOT set in production.
+# OAUTHLIB_INSECURE_TRANSPORT=1

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -67,8 +67,11 @@ def create_app(config_class=Config):
     # so HTTPS and host detection still work for url_for(..., _external=True).
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=0, x_proto=1, x_host=1)
 
+    from app.routes.admin import admin_bp, google_bp
     from app.routes.main import main_bp
 
     app.register_blueprint(main_bp)
+    app.register_blueprint(google_bp, url_prefix="/login")
+    app.register_blueprint(admin_bp)
 
     return app

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1,0 +1,63 @@
+"""Admin OAuth gate — Google sign-in against an email allowlist.
+
+Operational auth for the admin dashboard. Not part of the study protocol:
+participants remain fully anonymous (see app/services/session_identity.py).
+Admin identity lives in session["admin_email"], which is a separate key from
+session["session_id"] and never joined to study data.
+"""
+
+from functools import wraps
+
+from flask import (
+    Blueprint,
+    abort,
+    current_app,
+    redirect,
+    render_template,
+    session,
+    url_for,
+)
+from flask_dance.contrib.google import google, make_google_blueprint
+
+ADMIN_EMAIL_KEY = "admin_email"
+
+admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
+google_bp = make_google_blueprint(scope=["email"])
+
+
+def _admin_allowlist():
+    raw = current_app.config.get("ADMIN_EMAILS", "") or ""
+    return {e.strip().lower() for e in raw.split(",") if e.strip()}
+
+
+def admin_required(f):
+    """Allow the request only if session["admin_email"] is in the allowlist."""
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        email = (session.get(ADMIN_EMAIL_KEY) or "").lower()
+        if email and email in _admin_allowlist():
+            return f(*args, **kwargs)
+        return redirect(url_for("admin.login"))
+
+    return decorated
+
+
+@admin_bp.route("/login")
+def login():
+    if not google.authorized:
+        return redirect(url_for("google.login"))
+    resp = google.get("/oauth2/v2/userinfo")
+    if not resp.ok:
+        abort(403)
+    email = (resp.json().get("email") or "").lower()
+    if email not in _admin_allowlist():
+        return render_template("admin_unauthorized.html", email=email), 403
+    session[ADMIN_EMAIL_KEY] = email
+    return redirect(url_for("main.dashboard"))
+
+
+@admin_bp.route("/logout")
+def logout():
+    session.pop(ADMIN_EMAIL_KEY, None)
+    return redirect(url_for("main.index"))

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import random
+from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 
 from flask import (
@@ -31,6 +32,7 @@ from app.models import (
     Visit,
     db,
 )
+from app.routes.admin import admin_required
 from app.services.session_identity import (
     consent_required,
     get_session_id,
@@ -216,12 +218,13 @@ def stylists():
 
 
 # ---------------------------------------------------------------------------
-# Admin dashboard / export — ungated pending issue #16 (decision: drop or gate).
-# Queries rewritten to use ExperimentSession/session_id instead of the removed User model.
+# Admin dashboard / export — gated by Google OAuth email allowlist (issue #63).
+# See app/routes/admin.py for the allowlist and decorator.
 # ---------------------------------------------------------------------------
 
 
 @main_bp.route("/dashboard")
+@admin_required
 def dashboard():
     """Render the admin KPI dashboard with analytics metrics."""
     log_visit("KPI Dashboard")
@@ -387,14 +390,39 @@ def dashboard():
 
 
 @main_bp.route("/api/admin/export")
+@admin_required
 def export_data():
-    """Export anonymized experiment data. Iterates ExperimentSession (one row per consented participant)."""
-    sessions = ExperimentSession.query.order_by(ExperimentSession.started_at).all()
+    """Export anonymized experiment data, aggregated per participant (session_id).
+
+    A single participant may have multiple ExperimentSession rows if they timed
+    out and resumed (see api_session_start). Iterating ExperimentSession
+    directly produces duplicate participant rows and double-counts images and
+    ratings (which are queried by session_id, not ExperimentSession.id).
+    """
+    all_sessions = ExperimentSession.query.order_by(ExperimentSession.started_at).all()
+
+    by_sid = defaultdict(list)
+    for s in all_sessions:
+        by_sid[s.session_id].append(s)
+
+    ordered_sids = sorted(by_sid.keys(), key=lambda sid: by_sid[sid][0].started_at)
 
     rows = []
+    for i, sid in enumerate(ordered_sids, 1):
+        sess_rows = by_sid[sid]
+        experiment_group = sess_rows[0].experiment_group
 
-    for i, sess in enumerate(sessions, 1):
-        sid = sess.session_id
+        total_duration = 0
+        have_any_duration = False
+        for sr in sess_rows:
+            if sr.duration_seconds is not None:
+                total_duration += sr.duration_seconds
+                have_any_duration = True
+            elif sr.last_ping_at and sr.started_at:
+                total_duration += int((sr.last_ping_at - sr.started_at).total_seconds())
+                have_any_duration = True
+        duration = total_duration if have_any_duration else None
+
         gen_images = GeneratedImage.query.filter_by(session_id=sid).all()
         num_visualizations = len(gen_images)
 
@@ -403,10 +431,6 @@ def export_data():
             round(sum(r.rating for r in ratings) / len(ratings), 2) if ratings else None
         )
         num_ratings = len(ratings)
-
-        duration = sess.duration_seconds
-        if duration is None and sess.last_ping_at and sess.started_at:
-            duration = int((sess.last_ping_at - sess.started_at).total_seconds())
 
         consent = Consent.query.filter_by(session_id=sid).first()
         consented_at = consent.consented_at.isoformat() if consent else None
@@ -418,7 +442,7 @@ def export_data():
         rows.append(
             {
                 "participant_id": i,
-                "experiment_group": sess.experiment_group,
+                "experiment_group": experiment_group,
                 "num_visualizations": num_visualizations,
                 "avg_rating": avg_rating,
                 "num_ratings": num_ratings,

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -60,7 +60,7 @@ def _load_validated_photo(photo_file):
     try:
         probe = Image.open(io.BytesIO(photo_bytes))
         probe.verify()
-    except UnidentifiedImageError, OSError, SyntaxError, ValueError:
+    except (UnidentifiedImageError, OSError, SyntaxError, ValueError):
         return None, (jsonify({"error": "Invalid or corrupted image"}), 400)
 
     # verify() leaves the image unusable; reopen for real use.

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -62,7 +62,7 @@ def _load_validated_photo(photo_file):
     try:
         probe = Image.open(io.BytesIO(photo_bytes))
         probe.verify()
-    except (UnidentifiedImageError, OSError, SyntaxError, ValueError):
+    except (UnidentifiedImageError, OSError, SyntaxError, ValueError):  # fmt: skip
         return None, (jsonify({"error": "Invalid or corrupted image"}), 400)
 
     # verify() leaves the image unusable; reopen for real use.

--- a/app/templates/admin_unauthorized.html
+++ b/app/templates/admin_unauthorized.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+
+{% block title %}Access denied - TrueHair AI{% endblock %}
+
+{% block navbar %}{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8 col-lg-6">
+            <div class="card bg-dark border-secondary">
+                <div class="card-body p-5 text-center">
+                    <i class="bi bi-shield-lock-fill text-warning" style="font-size: 3rem;"></i>
+                    <h1 class="h3 text-white mt-3 mb-3">Access denied</h1>
+                    <p class="text-secondary mb-2">
+                        The Google account <strong class="text-white">{{ email }}</strong>
+                        is not on the admin allowlist.
+                    </p>
+                    <p class="text-secondary small mb-4">
+                        If you believe you should have access, contact the study administrator.
+                    </p>
+                    <a href="{{ url_for('admin.logout') }}" class="btn btn-outline-light">
+                        Sign out
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -30,3 +30,9 @@ class Config:
     R2_ACCESS_KEY_ID = os.environ.get("R2_ACCESS_KEY_ID")
     R2_SECRET_ACCESS_KEY = os.environ.get("R2_SECRET_ACCESS_KEY")
     R2_BUCKET_NAME = os.environ.get("R2_BUCKET_NAME")
+
+    # Admin dashboard OAuth gate (issue #63). Operational auth only — not part
+    # of the study protocol; participants never see this flow.
+    ADMIN_EMAILS = os.environ.get("ADMIN_EMAILS", "")
+    GOOGLE_OAUTH_CLIENT_ID = os.environ.get("GOOGLE_OAUTH_CLIENT_ID")
+    GOOGLE_OAUTH_CLIENT_SECRET = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.14"
 dependencies = [
     "flask>=3.1.3",
+    "flask-dance>=7.1.0",
     "flask-migrate>=4.1.0",
     "flask-sqlalchemy>=3.1.1",
     "google-genai>=1.66.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,9 @@ class TestConfig(Config):
     R2_ACCESS_KEY_ID = "test-access-key"
     R2_SECRET_ACCESS_KEY = "test-secret-key"
     R2_BUCKET_NAME = "test-bucket"
+    ADMIN_EMAILS = "admin@example.com,other-admin@example.com"
+    GOOGLE_OAUTH_CLIENT_ID = "test-client-id"
+    GOOGLE_OAUTH_CLIENT_SECRET = "test-client-secret"
 
 
 @pytest.fixture
@@ -78,6 +81,15 @@ def auth_client(app, session_id):
     client = app.test_client()
     with client.session_transaction() as sess:
         sess["session_id"] = session_id
+    return client
+
+
+@pytest.fixture
+def admin_client(app):
+    """Test client with an allowlisted admin_email cookie set (no session_id)."""
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["admin_email"] = "admin@example.com"
     return client
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -180,18 +180,56 @@ def test_stylists_search(auth_client, stylist):
 
 
 # ---------------------------------------------------------------------------
-# Dashboard + export (ungated pending issue #16).
+# Dashboard + export: admin OAuth email-allowlist gating (issue #63).
 # ---------------------------------------------------------------------------
 
 
-def test_dashboard_renders(client):
+def test_dashboard_redirects_to_login_when_unauthenticated(client):
+    """No admin_email cookie -> redirect to /admin/login."""
     response = client.get("/dashboard")
+    assert response.status_code == 302
+    assert "/admin/login" in response.location
+
+
+def test_dashboard_redirects_to_login_for_non_allowlisted_admin_email(client):
+    """admin_email set but not on the allowlist -> redirect to /admin/login (no trust)."""
+    with client.session_transaction() as sess:
+        sess["admin_email"] = "random@evil.example"
+    response = client.get("/dashboard")
+    assert response.status_code == 302
+    assert "/admin/login" in response.location
+
+
+def test_dashboard_allowed_for_allowlisted_admin(admin_client):
+    """admin_email on the allowlist -> dashboard renders."""
+    response = admin_client.get("/dashboard")
     assert response.status_code == 200
 
 
-def test_admin_export_json(app, client):
-    _consent_and_login(app, client)
-    response = client.get("/api/admin/export?format=json")
+def test_dashboard_blocks_participant_session(auth_client):
+    """A consented participant (session_id only, no admin_email) cannot access /dashboard."""
+    response = auth_client.get("/dashboard")
+    assert response.status_code == 302
+    assert "/admin/login" in response.location
+
+
+def test_admin_cookie_independent_of_session_id(app, admin_client):
+    """An admin cookie without a session_id can access /dashboard and /api/admin/export."""
+    with admin_client.session_transaction() as sess:
+        assert "session_id" not in sess
+    assert admin_client.get("/dashboard").status_code == 200
+    assert admin_client.get("/api/admin/export?format=json").status_code == 200
+
+
+def test_admin_export_redirects_when_unauthenticated(client):
+    response = client.get("/api/admin/export")
+    assert response.status_code == 302
+    assert "/admin/login" in response.location
+
+
+def test_admin_export_json(app, admin_client):
+    _consent_and_login(app, admin_client)
+    response = admin_client.get("/api/admin/export?format=json")
     assert response.status_code == 200
 
     data = response.get_json()
@@ -215,9 +253,9 @@ def test_admin_export_json(app, client):
     assert "last_name" not in row
 
 
-def test_admin_export_csv(app, client):
-    _consent_and_login(app, client)
-    response = client.get("/api/admin/export")
+def test_admin_export_csv(app, admin_client):
+    _consent_and_login(app, admin_client)
+    response = admin_client.get("/api/admin/export")
     assert response.status_code == 200
     assert response.headers["Content-Type"].startswith("text/csv")
     assert "attachment" in response.headers["Content-Disposition"]
@@ -227,17 +265,59 @@ def test_admin_export_csv(app, client):
     assert "experiment_group" in csv_data
 
 
-def test_admin_export_iterates_experiment_sessions(app, client):
-    """Export emits one row per ExperimentSession row."""
-    _consent_and_login(app, client, experiment_group="control")
-    _consent_and_login(app, client, experiment_group="experimental")
-    response = client.get("/api/admin/export?format=json")
+def test_admin_export_one_row_per_participant(app, admin_client):
+    """Export emits one row per unique session_id, not per ExperimentSession row."""
+    _consent_and_login(app, admin_client, experiment_group="control")
+    _consent_and_login(app, admin_client, experiment_group="experimental")
+    response = admin_client.get("/api/admin/export?format=json")
     data = response.get_json()
     assert len(data) == 2
 
 
-def test_admin_export_invalid_format(client):
-    response = client.get("/api/admin/export?format=xml")
+def test_admin_export_dedupes_timeout_resume_sessions(app, admin_client):
+    """A participant with multiple ExperimentSession rows (timeout+resume) yields one export row.
+
+    Images and ratings must not be double-counted; session_duration_seconds must
+    be the sum across rows for that participant.
+    """
+    sid = str(uuid.uuid4())
+    started = datetime.now(timezone.utc)
+
+    with app.app_context():
+        db.session.add(Consent(session_id=sid, experiment_group="control"))
+        db.session.add(
+            ExperimentSession(
+                session_id=sid,
+                experiment_group="control",
+                started_at=started,
+                last_ping_at=started,
+                ended_at=started,
+                duration_seconds=120,
+            )
+        )
+        db.session.add(
+            ExperimentSession(
+                session_id=sid,
+                experiment_group="control",
+                started_at=started,
+                last_ping_at=started,
+                ended_at=started,
+                duration_seconds=300,
+            )
+        )
+        db.session.commit()
+
+    response = admin_client.get("/api/admin/export?format=json")
+    assert response.status_code == 200
+    data = response.get_json()
+
+    matching = [r for r in data if r["session_duration_seconds"] == 420]
+    assert len(matching) == 1, f"expected one merged row, got {data}"
+    assert matching[0]["experiment_group"] == "control"
+
+
+def test_admin_export_invalid_format(admin_client):
+    response = admin_client.get("/api/admin/export?format=xml")
     assert response.status_code == 400
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -308,6 +308,23 @@ wheels = [
 ]
 
 [[package]]
+name = "flask-dance"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "oauthlib" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "urlobject" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/b3/38aff96fbafe850f7f4186dc06e96ebc29625d68d1427ad65c9d41c4ec9e/flask_dance-7.1.0.tar.gz", hash = "sha256:6d0510e284f3d6ff05af918849791b17ef93a008628ec33f3a80578a44b51674", size = 140993, upload-time = "2024-03-05T12:43:21.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/8c/4125e9f1196e5ab9675d38ff445ae4abd7085aba7551335980ac19196389/flask_dance-7.1.0-py3-none-any.whl", hash = "sha256:81599328a2b3604fd4332b3d41a901cf36980c2067e5e38c44ce3b85c4e1ae9c", size = 62176, upload-time = "2024-03-05T12:43:19.149Z" },
+]
+
+[[package]]
 name = "flask-migrate"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -551,6 +568,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -861,6 +887,19 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.5"
 source = { registry = "https://pypi.org/simple" }
@@ -957,6 +996,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "boto3" },
     { name = "flask" },
+    { name = "flask-dance" },
     { name = "flask-migrate" },
     { name = "flask-sqlalchemy" },
     { name = "google-genai" },
@@ -980,6 +1020,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.38.0" },
     { name = "flask", specifier = ">=3.1.3" },
+    { name = "flask-dance", specifier = ">=7.1.0" },
     { name = "flask-migrate", specifier = ">=4.1.0" },
     { name = "flask-sqlalchemy", specifier = ">=3.1.1" },
     { name = "google-genai", specifier = ">=1.66.0" },
@@ -1027,6 +1068,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "urlobject"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/fd/163e6b835b9fabf9c3999f71c5f224daa9d68a38012cccd7ab2a2f861af9/urlobject-3.0.0.tar.gz", hash = "sha256:bfdfe70746d92a039a33e964959bb12cecd9807a434fdb7fef5f38e70a295818", size = 28237, upload-time = "2025-07-11T17:53:22.877Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/38/18c4bbe751a7357b3f6a33352e3af3305ad78f3e72ab7e3d667de4663ed9/urlobject-3.0.0-py3-none-any.whl", hash = "sha256:fd2465520d0a8c5ed983aa47518a2c5bcde0c276a4fd0eb28b0de5dcefd93b1e", size = 16261, upload-time = "2025-07-11T17:53:21.989Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Re-gates `/dashboard` and `/api/admin/export` behind a Google OAuth email allowlist so these admin routes stop 500ing after the `User` model removal (#48, #49). Admin auth is a separate code path from the participant flow — participants remain fully anonymous (`session_id` only), admins sign in with Google and identity lives in `session["admin_email"]`, never joined to study data. Also fixes a duplicate-row / double-count bug in the CSV export by aggregating per `session_id`.

See the design discussion in #63 for why OAuth over shared-secret tokens or dropping the dashboard.

## Related Issues
Closes #63.
Depends on #83 (pre-existing Python 3 syntax error in `app/routes/main.py` blocks test collection). The first commit on this branch matches that PR — once #83 merges to `main`, rebasing this branch will drop it cleanly.

## Changes Made
- [x] Added `flask-dance>=7.1.0` and registered `google_bp` (under `/login`) and `admin_bp` (`/admin`) in the app factory.
- [x] New `app/routes/admin.py`: `admin_required` decorator keyed on `session["admin_email"]` against the `ADMIN_EMAILS` allowlist; `/admin/login` (OAuth redirect + allowlist check) and `/admin/logout` routes.
- [x] Applied `@admin_required` to `/dashboard` and `/api/admin/export`.
- [x] Rewrote export aggregation: one row per unique `session_id` (not per `ExperimentSession` row), duration summed across resumed sessions, images and ratings no longer double-counted.
- [x] Added `ADMIN_EMAILS`, `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET` to `config.py` and `.env.example`.
- [x] New `admin_unauthorized.html` 403 template for logged-in but non-allowlisted emails.
- [x] `base.html` has no admin link (stays removed per #49).

## Testing & Verification
- `pytest` — 64 passed, 1 pre-existing deprecation warning. New cases: `test_dashboard_redirects_to_login_when_unauthenticated`, `test_dashboard_redirects_to_login_for_non_allowlisted_admin_email`, `test_dashboard_allowed_for_allowlisted_admin`, `test_dashboard_blocks_participant_session`, `test_admin_cookie_independent_of_session_id`, `test_admin_export_redirects_when_unauthenticated`, `test_admin_export_dedupes_timeout_resume_sessions`.
- Session isolation test asserts both halves: a participant cookie (`session_id` only) is redirected from `/dashboard`, and an admin cookie (`admin_email` only, no `session_id`) can access both `/dashboard` and `/api/admin/export`.
- Export dedupe test creates two `ExperimentSession` rows for one `session_id` (simulating timeout+resume) and asserts exactly one export row with summed duration.

### Still to do before shipping
- Configure the OAuth 2.0 client in the existing `GOOGLE_CLOUD_PROJECT` with authorized redirect URIs `http://localhost:5000/login/google/authorized` (dev) and `https://<prod-host>/login/google/authorized` (prod), scopes `openid`, `email` only.
- Populate `ADMIN_EMAILS`, `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET` in the prod environment.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google OAuth sign-in for the admin dashboard with admin allowlist, login/logout flows, and an "Access denied" page for non-allowlisted accounts
  * New configuration options and example env entries for admin emails and OAuth credentials

* **Bug Fixes**
  * Export now deduplicates multi-session participants and sums their session durations (one row per participant)

* **Tests**
  * Expanded tests covering admin access rules and consolidated export behavior

* **Chores**
  * Added OAuth library dependency and test fixtures for admin scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->