### PR TITLE
feat(dashboard): Implement new dashboard tab for experiment data

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -22,7 +22,11 @@ from flask_dance.contrib.google import google, make_google_blueprint
 ADMIN_EMAIL_KEY = "admin_email"
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
-google_bp = make_google_blueprint(scope=["email"])
+# redirect_to routes the post-OAuth hop back through admin.login so it can read
+# userinfo, set session["admin_email"], and redirect to the dashboard. Without
+# this, Flask-Dance falls back to "/" after a successful callback and a browser
+# with a participant session_id cookie ends up on /style-studio.
+google_bp = make_google_blueprint(scope=["email"], redirect_to="admin.login")
 
 
 def _admin_allowlist():

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import random
+import statistics
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 
@@ -223,11 +224,213 @@ def stylists():
 # ---------------------------------------------------------------------------
 
 
+ENROLLMENT_TARGET = 50  # upper bound of IRB target (20–50)
+
+
+def _bin_values(values, bin_edges):
+    """Return list of counts per bin. Values exactly equal to an upper edge go into that bin
+    (except the final bin, which is inclusive of its upper edge). Empty input returns zeros."""
+    if not bin_edges or len(bin_edges) < 2:
+        return []
+    counts = [0] * (len(bin_edges) - 1)
+    for v in values:
+        for i in range(len(bin_edges) - 1):
+            lo, hi = bin_edges[i], bin_edges[i + 1]
+            is_last = i == len(bin_edges) - 2
+            if (lo <= v < hi) or (is_last and v == hi):
+                counts[i] += 1
+                break
+        # Values outside [bin_edges[0], bin_edges[-1]] are silently dropped.
+        # Callers are responsible for choosing edges that cover the data range.
+    return counts
+
+
+def _describe(values):
+    """Return descriptive stats dict for a list of numeric values. Safe for empty input."""
+    vals = [v for v in values if v is not None]
+    n = len(vals)
+    if n == 0:
+        return {
+            "n": 0,
+            "mean": None,
+            "stdev": None,
+            "median": None,
+            "min": None,
+            "max": None,
+        }
+    return {
+        "n": n,
+        "mean": round(statistics.mean(vals), 2),
+        "stdev": round(statistics.stdev(vals), 2) if n > 1 else 0.0,
+        "median": round(statistics.median(vals), 2),
+        "min": min(vals),
+        "max": max(vals),
+    }
+
+
+def _experiment_metrics():
+    """Compute per-group aggregates for the Experiment dashboard.
+
+    Returns a dict with keys consumed by experiment_dashboard.html. All per-group
+    breakdowns are keyed by "control" and "experimental". Participants are de-duplicated
+    by session_id (a participant with multiple ExperimentSession rows counts once),
+    matching the aggregation rule used by /api/admin/export.
+    """
+    all_sessions = ExperimentSession.query.order_by(ExperimentSession.started_at).all()
+    by_sid = defaultdict(list)
+    for s in all_sessions:
+        by_sid[s.session_id].append(s)
+
+    ratings_by_group = {"control": [], "experimental": []}
+    viz_count_by_group = {"control": [], "experimental": []}
+    duration_by_group = {"control": [], "experimental": []}
+
+    ai_rec_rate_values = []
+
+    zero_viz_by_group = {"control": 0, "experimental": 0}
+    zero_rating_by_group = {"control": 0, "experimental": 0}
+
+    for sid, sess_rows in by_sid.items():
+        group = sess_rows[0].experiment_group
+        if group not in ("control", "experimental"):
+            continue
+
+        total_duration = 0
+        have_any_duration = False
+        for sr in sess_rows:
+            if sr.duration_seconds is not None:
+                total_duration += sr.duration_seconds
+                have_any_duration = True
+            elif sr.last_ping_at and sr.started_at:
+                total_duration += int((sr.last_ping_at - sr.started_at).total_seconds())
+                have_any_duration = True
+        if have_any_duration:
+            duration_by_group[group].append(total_duration)
+
+        gen_images = GeneratedImage.query.filter_by(session_id=sid).all()
+        n_viz = len(gen_images)
+        viz_count_by_group[group].append(n_viz)
+        if n_viz == 0:
+            zero_viz_by_group[group] += 1
+
+        participant_ratings = Rating.query.filter_by(session_id=sid).all()
+        if participant_ratings:
+            mean_r = statistics.mean(r.rating for r in participant_ratings)
+            ratings_by_group[group].append(mean_r)
+        else:
+            zero_rating_by_group[group] += 1
+
+        if group == "experimental" and n_viz > 0:
+            ai_count = sum(1 for gi in gen_images if gi.was_ai_recommended is True)
+            ai_rec_rate_values.append(ai_count / n_viz)
+
+    rating_stats = {
+        g: _describe(ratings_by_group[g]) for g in ("control", "experimental")
+    }
+    viz_stats = {
+        g: _describe(viz_count_by_group[g]) for g in ("control", "experimental")
+    }
+    duration_stats = {
+        g: _describe(duration_by_group[g]) for g in ("control", "experimental")
+    }
+
+    rating_bin_edges = [1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]
+    rating_bin_labels = [
+        "1.0–1.5",
+        "1.5–2.0",
+        "2.0–2.5",
+        "2.5–3.0",
+        "3.0–3.5",
+        "3.5–4.0",
+        "4.0–4.5",
+        "4.5–5.0",
+    ]
+    rating_hist = {
+        g: _bin_values(ratings_by_group[g], rating_bin_edges)
+        for g in ("control", "experimental")
+    }
+
+    viz_bin_labels = ["0", "1", "2", "3", "4", "5", "6+"]
+    viz_hist = {"control": [0] * 7, "experimental": [0] * 7}
+    for g in ("control", "experimental"):
+        for v in viz_count_by_group[g]:
+            idx = min(int(v), 6)
+            viz_hist[g][idx] += 1
+
+    duration_bin_edges_seconds = [0, 60, 180, 300, 600, 900, float("inf")]
+    duration_bin_labels = ["<1m", "1–3m", "3–5m", "5–10m", "10–15m", "15m+"]
+    duration_hist = {"control": [0] * 6, "experimental": [0] * 6}
+    for g in ("control", "experimental"):
+        for d in duration_by_group[g]:
+            for i in range(len(duration_bin_edges_seconds) - 1):
+                if (
+                    duration_bin_edges_seconds[i]
+                    <= d
+                    < duration_bin_edges_seconds[i + 1]
+                ):
+                    duration_hist[g][i] += 1
+                    break
+
+    ai_rec_stats = _describe(ai_rec_rate_values)
+    ai_rec_bin_labels = ["0–20%", "20–40%", "40–60%", "60–80%", "80–100%"]
+    ai_rec_bin_edges = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+    ai_rec_hist = _bin_values(ai_rec_rate_values, ai_rec_bin_edges)
+
+    n_control = len(viz_count_by_group["control"])
+    n_experimental = len(viz_count_by_group["experimental"])
+    n_total = n_control + n_experimental
+
+    completeness = {
+        "zero_viz": zero_viz_by_group,
+        "zero_rating": zero_rating_by_group,
+        "total_consented": {
+            "control": n_control,
+            "experimental": n_experimental,
+        },
+    }
+
+    return {
+        "n_control": n_control,
+        "n_experimental": n_experimental,
+        "n_total": n_total,
+        "enrollment_target": ENROLLMENT_TARGET,
+        "rating_stats": rating_stats,
+        "viz_stats": viz_stats,
+        "duration_stats": duration_stats,
+        "ai_rec_stats": ai_rec_stats,
+        "rating_hist": rating_hist,
+        "rating_bin_labels": rating_bin_labels,
+        "viz_hist": viz_hist,
+        "viz_bin_labels": viz_bin_labels,
+        "duration_hist": duration_hist,
+        "duration_bin_labels": duration_bin_labels,
+        "ai_rec_hist": ai_rec_hist,
+        "ai_rec_bin_labels": ai_rec_bin_labels,
+        "completeness": completeness,
+    }
+
+
 @main_bp.route("/dashboard")
 @admin_required
 def dashboard():
+    """Redirect legacy /dashboard to the Experiment tab (new default landing)."""
+    return redirect(url_for("main.experiment_dashboard"))
+
+
+@main_bp.route("/dashboard/experiment")
+@admin_required
+def experiment_dashboard():
+    """Render the study-focused dashboard with per-group KPI breakdowns."""
+    log_visit("Experiment Dashboard")
+    metrics = _experiment_metrics()
+    return render_template("experiment_dashboard.html", **metrics)
+
+
+@main_bp.route("/dashboard/operations")
+@admin_required
+def operations_dashboard():
     """Render the admin KPI dashboard with analytics metrics."""
-    log_visit("KPI Dashboard")
+    log_visit("Operations Dashboard")
 
     now = datetime.now()
     today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -370,7 +573,7 @@ def dashboard():
     visit_data = list(mapped_vp.values())
 
     return render_template(
-        "dashboard.html",
+        "operations_dashboard.html",
         visits_today=visits_today,
         visit_change=round(visit_change, 1),
         new_users=new_participants,

--- a/app/templates/_admin_sidebar.html
+++ b/app/templates/_admin_sidebar.html
@@ -1,0 +1,37 @@
+{# Shared admin sidebar. Callers must pass `active_tab` as "experiment" or "operations". #}
+<div class="sidebar d-flex flex-column p-4 flex-shrink-0" style="width: 280px; background-color: #1a1b24;">
+    <a class="navbar-brand d-flex flex-column gap-1 mb-5" href="{{ url_for('main.style_studio') }}">
+        <div class="d-flex align-items-center gap-2">
+            <img src="{{ url_for('static', filename='images/truehair-logo.png') }}" alt="TrueHair Logo" height="32">
+            <span class="brand-text text-white fw-bold fs-5">TrueHair AI</span>
+        </div>
+        <span class="text-secondary" style="font-size: 0.65rem; letter-spacing: 1px; font-weight: 600;">ADMIN CONSOLE</span>
+    </a>
+
+    <ul class="nav nav-pills flex-column mb-auto gap-2">
+        <li class="nav-item">
+            <a href="{{ url_for('main.experiment_dashboard') }}"
+               class="nav-link d-flex align-items-center gap-3 rounded-3 py-3 px-3
+                      {% if active_tab == 'experiment' %}fw-bold shadow text-dark{% else %}text-white{% endif %}"
+               {% if active_tab == 'experiment' %}style="background-color: var(--th-yellow);"{% endif %}>
+                <i class="bi bi-beaker fs-5"></i>
+                Experiment
+            </a>
+        </li>
+        <li class="nav-item">
+            <a href="{{ url_for('main.operations_dashboard') }}"
+               class="nav-link d-flex align-items-center gap-3 rounded-3 py-3 px-3
+                      {% if active_tab == 'operations' %}fw-bold shadow text-dark{% else %}text-white{% endif %}"
+               {% if active_tab == 'operations' %}style="background-color: var(--th-yellow);"{% endif %}>
+                <i class="bi bi-grid-1x2-fill fs-5"></i>
+                Operations
+            </a>
+        </li>
+    </ul>
+
+    <div class="mt-auto pt-3 border-top border-secondary border-opacity-25">
+        <a href="{{ url_for('admin.logout') }}" class="logout-btn text-decoration-none small d-flex align-items-center gap-2">
+            <i class="bi bi-box-arrow-right"></i> Sign out
+        </a>
+    </div>
+</div>

--- a/app/templates/experiment_dashboard.html
+++ b/app/templates/experiment_dashboard.html
@@ -1,0 +1,383 @@
+{% extends 'base.html' %}
+
+{% block title %}Experiment - TrueHair AI{% endblock %}
+{% block body_class %}bg-studio{% endblock %}
+{% block navbar %}{% endblock %}
+{% block footer %}{% endblock %}
+
+{% block content %}
+<div class="d-flex h-100 w-100">
+
+    {% set active_tab = 'experiment' %}
+    {% include '_admin_sidebar.html' %}
+
+    <!-- Main Content -->
+    <div class="flex-grow-1 d-flex flex-column overflow-auto h-100">
+
+        <!-- Top bar: title + export buttons -->
+        <div class="d-flex justify-content-between align-items-center py-4 px-5 border-bottom border-secondary border-opacity-25"
+             style="background-color: var(--th-bg-studio);">
+            <div class="d-flex align-items-center gap-2">
+                <i class="bi bi-beaker text-white fs-4"></i>
+                <h3 class="fw-bold mb-0 text-white">Experiment</h3>
+            </div>
+            <div class="d-flex gap-2">
+                <a href="{{ url_for('main.export_data', format='csv') }}"
+                   class="btn rounded-3 px-3 py-2 fw-semibold"
+                   style="background-color: var(--th-yellow); color: #000;">
+                    <i class="bi bi-download me-1"></i> Export CSV
+                </a>
+                <a href="{{ url_for('main.export_data', format='json') }}"
+                   class="btn rounded-3 px-3 py-2 fw-semibold border"
+                   style="border-color: rgba(255,255,255,0.1); color: #fff;">
+                    <i class="bi bi-filetype-json me-1"></i> Export JSON
+                </a>
+            </div>
+        </div>
+
+        <div class="p-5 flex-grow-1" style="background-color: var(--th-bg-studio);">
+
+            <!-- Enrollment strip -->
+            <div class="row g-4 mb-5">
+                <div class="col-xl-4 col-md-12">
+                    <div class="card bg-card border border-secondary border-opacity-25 rounded-4 h-100 p-4 shadow-sm">
+                        <div class="d-flex justify-content-between align-items-start mb-3">
+                            <span class="text-secondary fw-semibold">Total enrolled</span>
+                            <i class="bi bi-people-fill text-yellow fs-5"></i>
+                        </div>
+                        <h2 class="fw-bold text-white mb-2">{{ n_total }} <span class="text-secondary fs-5">/ {{ enrollment_target }}</span></h2>
+                        <div class="progress" style="height: 8px; background-color: rgba(255,255,255,0.08);">
+                            <div class="progress-bar"
+                                 role="progressbar"
+                                 style="width: {{ (100 * n_total / enrollment_target) if enrollment_target else 0 }}%; background-color: var(--th-yellow);"
+                                 aria-valuenow="{{ n_total }}"
+                                 aria-valuemin="0"
+                                 aria-valuemax="{{ enrollment_target }}"></div>
+                        </div>
+                        <div class="text-secondary text-sm mt-2">Toward IRB target (20–50)</div>
+                    </div>
+                </div>
+
+                <div class="col-xl-4 col-md-6">
+                    <div class="card bg-card border border-secondary border-opacity-25 rounded-4 h-100 p-4 shadow-sm">
+                        <div class="d-flex justify-content-between align-items-start mb-3">
+                            <span class="text-secondary fw-semibold">Control group</span>
+                            <i class="bi bi-circle-fill" style="color: #4b4b53; font-size: 0.9rem;"></i>
+                        </div>
+                        <h2 class="fw-bold text-white mb-2">{{ n_control }}</h2>
+                        <div class="text-secondary text-sm">
+                            {% if n_total > 0 %}{{ (100 * n_control / n_total) | round(0, 'floor') | int }}% of enrolled{% else %}—{% endif %}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-xl-4 col-md-6">
+                    <div class="card bg-card border border-secondary border-opacity-25 rounded-4 h-100 p-4 shadow-sm">
+                        <div class="d-flex justify-content-between align-items-start mb-3">
+                            <span class="text-secondary fw-semibold">Experimental group</span>
+                            <i class="bi bi-circle-fill text-yellow" style="font-size: 0.9rem;"></i>
+                        </div>
+                        <h2 class="fw-bold text-white mb-2">{{ n_experimental }}</h2>
+                        <div class="text-secondary text-sm">
+                            {% if n_total > 0 %}{{ (100 * n_experimental / n_total) | round(0, 'floor') | int }}% of enrolled{% else %}—{% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Primary KPI: Average star rating -->
+            <div class="card bg-card border border-secondary border-opacity-25 rounded-4 p-4 shadow-sm mb-4">
+                <div class="d-flex justify-content-between align-items-start mb-4">
+                    <div>
+                        <div class="badge rounded-pill px-3 py-2 mb-2 text-dark fw-bold" style="background-color: var(--th-yellow);">
+                            PRIMARY KPI
+                        </div>
+                        <h5 class="text-white fw-bold mb-1">Average star rating</h5>
+                        <div class="text-secondary text-sm">Per-participant mean of 1–5 star ratings, then averaged across participants in each group.</div>
+                    </div>
+                </div>
+
+                <div class="row g-4">
+                    {% for group, color in [('control', '#4b4b53'), ('experimental', '#f8cd24')] %}
+                    <div class="col-md-6">
+                        <div class="p-3 rounded-3" style="background-color: rgba(255,255,255,0.02);">
+                            <div class="d-flex align-items-center gap-2 mb-3">
+                                <i class="bi bi-circle-fill" style="color: {{ color }}; font-size: 0.9rem;"></i>
+                                <span class="fw-bold text-white text-uppercase" style="font-size: 0.8rem; letter-spacing: 0.05em;">{{ group }}</span>
+                                <span class="text-secondary text-sm ms-auto">n = {{ rating_stats[group].n }}</span>
+                            </div>
+                            <div class="d-flex align-items-baseline gap-2 mb-1">
+                                <span class="fw-bold text-white" style="font-size: 2.5rem;">
+                                    {{ rating_stats[group].mean if rating_stats[group].mean is not none else '—' }}
+                                </span>
+                                <span class="text-secondary">mean</span>
+                            </div>
+                            <div class="text-secondary text-sm">
+                                SD {{ rating_stats[group].stdev if rating_stats[group].stdev is not none else '—' }}
+                                · Median {{ rating_stats[group].median if rating_stats[group].median is not none else '—' }}
+                                · Range {{ rating_stats[group].min if rating_stats[group].min is not none else '—' }}–{{ rating_stats[group].max if rating_stats[group].max is not none else '—' }}
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+
+                <div class="mt-4" style="height: 260px;">
+                    <canvas id="ratingHist"></canvas>
+                </div>
+            </div>
+
+            <!-- Secondary KPIs: Visualizations + Duration -->
+            <div class="row g-4 mb-4">
+                <div class="col-lg-6">
+                    <div class="card bg-card border border-secondary border-opacity-25 rounded-4 p-4 shadow-sm h-100">
+                        <div class="mb-3">
+                            <div class="badge rounded-pill px-3 py-2 mb-2 text-white fw-semibold" style="background-color: rgba(255,255,255,0.08);">
+                                SECONDARY
+                            </div>
+                            <h5 class="text-white fw-bold mb-1">Visualizations per participant</h5>
+                            <div class="text-secondary text-sm">Number of hairstyle generations each participant completed.</div>
+                        </div>
+
+                        <div class="row g-2 mb-3">
+                            {% for group, color in [('control', '#4b4b53'), ('experimental', '#f8cd24')] %}
+                            <div class="col-6">
+                                <div class="p-2 rounded-3" style="background-color: rgba(255,255,255,0.02);">
+                                    <div class="d-flex align-items-center gap-2 mb-1">
+                                        <i class="bi bi-circle-fill" style="color: {{ color }}; font-size: 0.7rem;"></i>
+                                        <span class="text-secondary text-sm text-uppercase" style="letter-spacing: 0.04em;">{{ group }}</span>
+                                    </div>
+                                    <div class="fw-bold text-white">
+                                        {{ viz_stats[group].mean if viz_stats[group].mean is not none else '—' }}
+                                        <span class="text-secondary fw-normal small">mean</span>
+                                    </div>
+                                    <div class="text-secondary small">
+                                        SD {{ viz_stats[group].stdev if viz_stats[group].stdev is not none else '—' }} · n = {{ viz_stats[group].n }}
+                                    </div>
+                                </div>
+                            </div>
+                            {% endfor %}
+                        </div>
+
+                        <div style="height: 220px;">
+                            <canvas id="vizHist"></canvas>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-lg-6">
+                    <div class="card bg-card border border-secondary border-opacity-25 rounded-4 p-4 shadow-sm h-100">
+                        <div class="mb-3">
+                            <div class="badge rounded-pill px-3 py-2 mb-2 text-white fw-semibold" style="background-color: rgba(255,255,255,0.08);">
+                                SECONDARY
+                            </div>
+                            <h5 class="text-white fw-bold mb-1">Session duration</h5>
+                            <div class="text-secondary text-sm">Total active time on the platform, summed across reconnects.</div>
+                        </div>
+
+                        <div class="row g-2 mb-3">
+                            {% for group, color in [('control', '#4b4b53'), ('experimental', '#f8cd24')] %}
+                            <div class="col-6">
+                                <div class="p-2 rounded-3" style="background-color: rgba(255,255,255,0.02);">
+                                    <div class="d-flex align-items-center gap-2 mb-1">
+                                        <i class="bi bi-circle-fill" style="color: {{ color }}; font-size: 0.7rem;"></i>
+                                        <span class="text-secondary text-sm text-uppercase" style="letter-spacing: 0.04em;">{{ group }}</span>
+                                    </div>
+                                    <div class="fw-bold text-white">
+                                        {% if duration_stats[group].mean is not none %}
+                                            {{ (duration_stats[group].mean / 60) | round(1) }}m
+                                        {% else %}—{% endif %}
+                                        <span class="text-secondary fw-normal small">mean</span>
+                                    </div>
+                                    <div class="text-secondary small">
+                                        {% if duration_stats[group].stdev is not none %}
+                                            SD {{ (duration_stats[group].stdev / 60) | round(1) }}m
+                                        {% else %}SD —{% endif %} · n = {{ duration_stats[group].n }}
+                                    </div>
+                                </div>
+                            </div>
+                            {% endfor %}
+                        </div>
+
+                        <div style="height: 220px;">
+                            <canvas id="durationHist"></canvas>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Experimental-only: AI recommendation selection rate -->
+            <div class="card bg-card border border-secondary border-opacity-25 rounded-4 p-4 shadow-sm mb-4">
+                <div class="d-flex justify-content-between align-items-start mb-4">
+                    <div>
+                        <div class="badge rounded-pill px-3 py-2 mb-2 text-dark fw-bold" style="background-color: var(--th-yellow);">
+                            EXPERIMENTAL GROUP ONLY
+                        </div>
+                        <h5 class="text-white fw-bold mb-1">AI recommendation selection rate</h5>
+                        <div class="text-secondary text-sm">
+                            Fraction of each experimental-group participant's visualizations that used an AI-recommended hairstyle.
+                            Low values suggest the manipulation isn't landing.
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row g-4 align-items-center">
+                    <div class="col-md-4">
+                        <div class="p-3 rounded-3" style="background-color: rgba(255,255,255,0.02);">
+                            <div class="d-flex align-items-baseline gap-2 mb-1">
+                                <span class="fw-bold text-white" style="font-size: 2.5rem;">
+                                    {% if ai_rec_stats.mean is not none %}
+                                        {{ (ai_rec_stats.mean * 100) | round(0, 'floor') | int }}%
+                                    {% else %}—{% endif %}
+                                </span>
+                                <span class="text-secondary">mean</span>
+                            </div>
+                            <div class="text-secondary text-sm">
+                                {% if ai_rec_stats.stdev is not none %}
+                                    SD {{ (ai_rec_stats.stdev * 100) | round(0, 'floor') | int }}%
+                                {% else %}SD —{% endif %}
+                                · n = {{ ai_rec_stats.n }}
+                            </div>
+                            <div class="text-secondary text-sm mt-2">
+                                Includes only experimental-group participants with ≥1 visualization.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-8">
+                        <div style="height: 200px;">
+                            <canvas id="aiRecHist"></canvas>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Data completeness -->
+            <div class="card bg-card border border-secondary border-opacity-25 rounded-4 p-4 shadow-sm">
+                <h5 class="text-white fw-bold mb-3">Data completeness</h5>
+                <div class="text-secondary text-sm mb-3">Participants who consented but produced no visualization or no rating. These are dropouts or incomplete sessions, not analysis rows.</div>
+                <table class="table table-dark table-sm mb-0" style="background-color: transparent;">
+                    <thead>
+                        <tr class="text-secondary" style="border-bottom: 1px solid rgba(255,255,255,0.08);">
+                            <th scope="col" class="fw-semibold">Group</th>
+                            <th scope="col" class="fw-semibold text-end">Consented</th>
+                            <th scope="col" class="fw-semibold text-end">Zero visualizations</th>
+                            <th scope="col" class="fw-semibold text-end">Zero ratings</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for group in ['control', 'experimental'] %}
+                        <tr>
+                            <td class="text-white text-uppercase" style="letter-spacing: 0.04em; font-size: 0.85rem;">{{ group }}</td>
+                            <td class="text-white text-end">{{ completeness.total_consented[group] }}</td>
+                            <td class="text-white text-end">{{ completeness.zero_viz[group] }}</td>
+                            <td class="text-white text-end">{{ completeness.zero_rating[group] }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+    Chart.defaults.color = "#a1a1aa";
+    Chart.defaults.font.family = "'Inter', sans-serif";
+
+    const CONTROL = "#4b4b53";
+    const EXPERIMENTAL = "#f8cd24";
+
+    function histOptions(xTitle) {
+        return {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: {
+                    display: true,
+                    position: 'top',
+                    align: 'end',
+                    labels: {
+                        boxWidth: 10,
+                        boxHeight: 10,
+                        usePointStyle: true,
+                        pointStyle: 'circle'
+                    }
+                },
+                tooltip: {
+                    backgroundColor: '#1a1b24',
+                    titleColor: '#fff',
+                    bodyColor: '#a1a1aa',
+                    borderColor: 'rgba(255, 255, 255, 0.1)',
+                    borderWidth: 1,
+                    padding: 10
+                }
+            },
+            scales: {
+                x: {
+                    title: { display: !!xTitle, text: xTitle || '', color: '#a1a1aa' },
+                    grid: { color: "rgba(255, 255, 255, 0.05)" }
+                },
+                y: {
+                    title: { display: true, text: 'Participants', color: '#a1a1aa' },
+                    grid: { color: "rgba(255, 255, 255, 0.05)" },
+                    beginAtZero: true,
+                    ticks: { precision: 0 }
+                }
+            }
+        };
+    }
+
+    new Chart(document.getElementById("ratingHist").getContext("2d"), {
+        type: "bar",
+        data: {
+            labels: {{ rating_bin_labels | tojson }},
+            datasets: [
+                { label: "Control", data: {{ rating_hist.control | tojson }}, backgroundColor: CONTROL, borderRadius: 4 },
+                { label: "Experimental", data: {{ rating_hist.experimental | tojson }}, backgroundColor: EXPERIMENTAL, borderRadius: 4 }
+            ]
+        },
+        options: histOptions('Mean rating (per participant)')
+    });
+
+    new Chart(document.getElementById("vizHist").getContext("2d"), {
+        type: "bar",
+        data: {
+            labels: {{ viz_bin_labels | tojson }},
+            datasets: [
+                { label: "Control", data: {{ viz_hist.control | tojson }}, backgroundColor: CONTROL, borderRadius: 4 },
+                { label: "Experimental", data: {{ viz_hist.experimental | tojson }}, backgroundColor: EXPERIMENTAL, borderRadius: 4 }
+            ]
+        },
+        options: histOptions('Visualizations generated')
+    });
+
+    new Chart(document.getElementById("durationHist").getContext("2d"), {
+        type: "bar",
+        data: {
+            labels: {{ duration_bin_labels | tojson }},
+            datasets: [
+                { label: "Control", data: {{ duration_hist.control | tojson }}, backgroundColor: CONTROL, borderRadius: 4 },
+                { label: "Experimental", data: {{ duration_hist.experimental | tojson }}, backgroundColor: EXPERIMENTAL, borderRadius: 4 }
+            ]
+        },
+        options: histOptions('Session duration')
+    });
+
+    new Chart(document.getElementById("aiRecHist").getContext("2d"), {
+        type: "bar",
+        data: {
+            labels: {{ ai_rec_bin_labels | tojson }},
+            datasets: [
+                { label: "Experimental", data: {{ ai_rec_hist | tojson }}, backgroundColor: EXPERIMENTAL, borderRadius: 4 }
+            ]
+        },
+        options: histOptions('Fraction of visualizations that were AI-recommended')
+    });
+});
+</script>
+{% endblock %}

--- a/app/templates/operations_dashboard.html
+++ b/app/templates/operations_dashboard.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% block title %}KPI Dashboard - TrueHair AI{% endblock %}
+{% block title %}Operations - TrueHair AI{% endblock %}
 
 {% block body_class %}bg-studio{% endblock %}
 
@@ -9,28 +9,8 @@
 {% block content %}
 <div class="d-flex h-100 w-100">
 
-    <!-- Sidebar -->
-    <div class="sidebar d-flex flex-column p-4 flex-shrink-0" style="width: 280px; background-color: #1a1b24;">
-        <a class="navbar-brand d-flex flex-column gap-1 mb-5" href="{{ url_for('main.style_studio') }}">
-            <div class="d-flex align-items-center gap-2">
-                <img src="{{ url_for('static', filename='images/truehair-logo.png') }}" alt="TrueHair Logo" height="32">
-                <span class="brand-text text-white fw-bold fs-5">TrueHair AI</span>
-            </div>
-            <span class="text-secondary" style="font-size: 0.65rem; letter-spacing: 1px; font-weight: 600;">ADMIN
-                CONSOLE</span>
-        </a>
-
-        <ul class="nav nav-pills flex-column mb-auto">
-            <li class="nav-item">
-                <a href="#"
-                    class="nav-link bg-yellow text-dark fw-bold d-flex align-items-center gap-3 rounded-3 py-3 px-3 shadow"
-                    style="background-color: var(--th-yellow);">
-                    <i class="bi bi-grid-1x2-fill fs-5"></i>
-                    Dashboard
-                </a>
-            </li>
-        </ul>
-    </div>
+    {% set active_tab = 'operations' %}
+    {% include '_admin_sidebar.html' %}
 
     <!-- Main Content -->
     <div class="flex-grow-1 d-flex flex-column overflow-auto h-100">
@@ -40,7 +20,7 @@
             style="background-color: var(--th-bg-studio);">
             <div class="d-flex align-items-center gap-2">
                 <i class="bi bi-grid-3x3-gap-fill text-white fs-4"></i>
-                <h3 class="fw-bold mb-0 text-white">KPI Dashboard</h3>
+                <h3 class="fw-bold mb-0 text-white">Operations</h3>
             </div>
         </div>
 
@@ -137,26 +117,6 @@
                                 class="text-secondary fw-normal">vs last week</span>
                         </div>
                     </div>
-                </div>
-            </div>
-
-            <!-- Export Section -->
-            <div class="d-flex justify-content-between align-items-center mb-4">
-                <div>
-                    <h5 class="text-white fw-bold mb-1">Experiment Data Export</h5>
-                    <div class="text-secondary text-sm">Download anonymized experiment data</div>
-                </div>
-                <div class="d-flex gap-2">
-                    <a href="{{ url_for('main.export_data', format='csv') }}"
-                       class="btn rounded-3 px-3 py-2 fw-semibold"
-                       style="background-color: var(--th-yellow); color: #000;">
-                        <i class="bi bi-download me-1"></i> CSV
-                    </a>
-                    <a href="{{ url_for('main.export_data', format='json') }}"
-                       class="btn rounded-3 px-3 py-2 fw-semibold border"
-                       style="border-color: rgba(255,255,255,0.1); color: #fff;">
-                        <i class="bi bi-filetype-json me-1"></i> JSON
-                    </a>
                 </div>
             </div>
 

--- a/tests/test_experiment_metrics.py
+++ b/tests/test_experiment_metrics.py
@@ -1,0 +1,246 @@
+"""Tests for the _experiment_metrics() aggregation helper used by the Experiment dashboard."""
+
+import uuid
+from datetime import datetime, timezone
+
+from app.models import (
+    Consent,
+    ExperimentSession,
+    GeneratedImage,
+    Rating,
+    db,
+)
+from app.routes.main import _experiment_metrics
+
+
+def _make_participant(
+    group, hairstyle_id, ratings=None, n_viz=0, n_ai_rec=0, duration_seconds=None
+):
+    """Create a fully-formed participant row set. Returns the session_id."""
+    sid = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+    db.session.add(Consent(session_id=sid, experiment_group=group))
+    db.session.add(
+        ExperimentSession(
+            session_id=sid,
+            experiment_group=group,
+            started_at=now,
+            last_ping_at=now,
+            ended_at=now,
+            duration_seconds=duration_seconds,
+        )
+    )
+
+    for i in range(n_viz):
+        gi = GeneratedImage(
+            session_id=sid,
+            hairstyle_id=hairstyle_id,
+            was_ai_recommended=(i < n_ai_rec) if group == "experimental" else None,
+        )
+        db.session.add(gi)
+        db.session.flush()
+        if ratings and i < len(ratings):
+            db.session.add(
+                Rating(
+                    session_id=sid,
+                    generated_image_id=gi.id,
+                    rating=ratings[i],
+                )
+            )
+
+    db.session.commit()
+    return sid
+
+
+def test_experiment_metrics_empty_db(app):
+    """With no data, all aggregates are zero or None."""
+    with app.app_context():
+        m = _experiment_metrics()
+        assert m["n_total"] == 0
+        assert m["n_control"] == 0
+        assert m["n_experimental"] == 0
+        assert m["rating_stats"]["control"]["n"] == 0
+        assert m["rating_stats"]["experimental"]["n"] == 0
+        assert m["rating_stats"]["control"]["mean"] is None
+        assert m["ai_rec_stats"]["n"] == 0
+        assert sum(m["rating_hist"]["control"]) == 0
+        assert sum(m["rating_hist"]["experimental"]) == 0
+
+
+def test_experiment_metrics_basic_split(app, hairstyle):
+    """Two participants in each group with realistic data produce correct per-group aggregates."""
+    with app.app_context():
+        _make_participant(
+            "control", hairstyle.id, ratings=[3, 4], n_viz=2, duration_seconds=300
+        )
+        _make_participant(
+            "control", hairstyle.id, ratings=[5], n_viz=1, duration_seconds=120
+        )
+        _make_participant(
+            "experimental",
+            hairstyle.id,
+            ratings=[5, 5, 4],
+            n_viz=3,
+            n_ai_rec=2,
+            duration_seconds=600,
+        )
+        _make_participant(
+            "experimental",
+            hairstyle.id,
+            ratings=[4],
+            n_viz=1,
+            n_ai_rec=1,
+            duration_seconds=240,
+        )
+
+        m = _experiment_metrics()
+
+        assert m["n_control"] == 2
+        assert m["n_experimental"] == 2
+        assert m["n_total"] == 4
+
+        assert m["rating_stats"]["control"]["n"] == 2
+        assert m["rating_stats"]["control"]["mean"] == 4.25
+        assert m["rating_stats"]["experimental"]["n"] == 2
+        assert abs(m["rating_stats"]["experimental"]["mean"] - 4.33) < 0.01
+
+        assert m["viz_stats"]["control"]["mean"] == 1.5
+        assert m["viz_stats"]["experimental"]["mean"] == 2.0
+
+        assert m["duration_stats"]["control"]["mean"] == 210.0
+        assert m["duration_stats"]["experimental"]["mean"] == 420.0
+
+        assert m["ai_rec_stats"]["n"] == 2
+        assert abs(m["ai_rec_stats"]["mean"] - 0.83) < 0.01
+
+
+def test_experiment_metrics_excludes_zero_rating_participants_from_rating_dist(
+    app, hairstyle
+):
+    """Participants with zero ratings are not in the rating distribution, but are counted in completeness."""
+    with app.app_context():
+        _make_participant(
+            "experimental", hairstyle.id, ratings=None, n_viz=0, duration_seconds=60
+        )
+        _make_participant(
+            "experimental",
+            hairstyle.id,
+            ratings=[5],
+            n_viz=1,
+            n_ai_rec=1,
+            duration_seconds=120,
+        )
+
+        m = _experiment_metrics()
+
+        assert m["rating_stats"]["experimental"]["n"] == 1
+        assert m["completeness"]["zero_viz"]["experimental"] == 1
+        assert m["completeness"]["zero_rating"]["experimental"] == 1
+        assert m["viz_stats"]["experimental"]["n"] == 2
+
+
+def test_experiment_metrics_deduplicates_timeout_resume(app, hairstyle):
+    """A participant with two ExperimentSession rows (timeout+resume) counts once; durations sum."""
+    with app.app_context():
+        sid = str(uuid.uuid4())
+        now = datetime.now(timezone.utc)
+        db.session.add(Consent(session_id=sid, experiment_group="control"))
+        db.session.add_all(
+            [
+                ExperimentSession(
+                    session_id=sid,
+                    experiment_group="control",
+                    started_at=now,
+                    last_ping_at=now,
+                    ended_at=now,
+                    duration_seconds=100,
+                ),
+                ExperimentSession(
+                    session_id=sid,
+                    experiment_group="control",
+                    started_at=now,
+                    last_ping_at=now,
+                    ended_at=now,
+                    duration_seconds=200,
+                ),
+            ]
+        )
+        db.session.commit()
+
+        m = _experiment_metrics()
+
+        assert m["n_control"] == 1
+        assert m["duration_stats"]["control"]["mean"] == 300.0
+
+
+def test_experiment_metrics_rating_histogram_bins(app, hairstyle):
+    """Rating histogram correctly bins per-participant means."""
+    with app.app_context():
+        _make_participant(
+            "control", hairstyle.id, ratings=[1], n_viz=1, duration_seconds=60
+        )
+        _make_participant(
+            "control", hairstyle.id, ratings=[2], n_viz=1, duration_seconds=60
+        )
+        _make_participant(
+            "control", hairstyle.id, ratings=[3], n_viz=1, duration_seconds=60
+        )
+        _make_participant(
+            "control", hairstyle.id, ratings=[4], n_viz=1, duration_seconds=60
+        )
+        _make_participant(
+            "control", hairstyle.id, ratings=[5], n_viz=1, duration_seconds=60
+        )
+
+        m = _experiment_metrics()
+        hist = m["rating_hist"]["control"]
+        assert hist == [1, 0, 1, 0, 1, 0, 1, 1]
+
+
+def test_experiment_metrics_viz_histogram_caps_at_6_plus(app, hairstyle):
+    """Participants with 6+ visualizations all land in the final '6+' bin."""
+    with app.app_context():
+        _make_participant(
+            "experimental",
+            hairstyle.id,
+            ratings=[5] * 6,
+            n_viz=6,
+            n_ai_rec=0,
+            duration_seconds=60,
+        )
+        _make_participant(
+            "experimental",
+            hairstyle.id,
+            ratings=[5] * 10,
+            n_viz=10,
+            n_ai_rec=0,
+            duration_seconds=60,
+        )
+
+        m = _experiment_metrics()
+        assert m["viz_hist"]["experimental"][6] == 2
+        assert m["viz_hist"]["experimental"][5] == 0
+
+
+def test_experiment_metrics_ignores_non_study_groups(app, hairstyle):
+    """Rows with an unexpected experiment_group value do not appear in the per-group breakdown."""
+    with app.app_context():
+        sid = str(uuid.uuid4())
+        now = datetime.now(timezone.utc)
+        db.session.add(Consent(session_id=sid, experiment_group="unknown"))
+        db.session.add(
+            ExperimentSession(
+                session_id=sid,
+                experiment_group="unknown",
+                started_at=now,
+                last_ping_at=now,
+                ended_at=now,
+                duration_seconds=60,
+            )
+        )
+        db.session.commit()
+
+        m = _experiment_metrics()
+        assert m["n_total"] == 0
+        assert m["n_control"] == 0
+        assert m["n_experimental"] == 0

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -201,9 +201,13 @@ def test_dashboard_redirects_to_login_for_non_allowlisted_admin_email(client):
 
 
 def test_dashboard_allowed_for_allowlisted_admin(admin_client):
-    """admin_email on the allowlist -> dashboard renders."""
+    """admin_email on the allowlist -> /dashboard redirects to the Experiment tab, which renders."""
     response = admin_client.get("/dashboard")
-    assert response.status_code == 200
+    assert response.status_code == 302
+    assert "/dashboard/experiment" in response.location
+
+    followed = admin_client.get("/dashboard", follow_redirects=True)
+    assert followed.status_code == 200
 
 
 def test_dashboard_blocks_participant_session(auth_client):
@@ -214,11 +218,84 @@ def test_dashboard_blocks_participant_session(auth_client):
 
 
 def test_admin_cookie_independent_of_session_id(app, admin_client):
-    """An admin cookie without a session_id can access /dashboard and /api/admin/export."""
+    """An admin cookie without a session_id can access dashboards and /api/admin/export."""
     with admin_client.session_transaction() as sess:
         assert "session_id" not in sess
-    assert admin_client.get("/dashboard").status_code == 200
+    assert admin_client.get("/dashboard/experiment").status_code == 200
+    assert admin_client.get("/dashboard/operations").status_code == 200
     assert admin_client.get("/api/admin/export?format=json").status_code == 200
+
+
+# -----------------------------------------------------------------------------
+# Dashboard split: /dashboard redirects to /dashboard/experiment
+# -----------------------------------------------------------------------------
+
+
+def test_dashboard_redirects_to_experiment_for_admin(admin_client):
+    """GET /dashboard redirects admins to the Experiment tab (new default landing)."""
+    response = admin_client.get("/dashboard")
+    assert response.status_code == 302
+    assert "/dashboard/experiment" in response.location
+
+
+def test_experiment_dashboard_renders_for_admin(admin_client):
+    """Experiment dashboard renders with 200 for allowlisted admin."""
+    response = admin_client.get("/dashboard/experiment")
+    assert response.status_code == 200
+    assert b"Experiment" in response.data
+    assert b"PRIMARY KPI" in response.data
+    assert b"Average star rating" in response.data
+
+
+def test_operations_dashboard_renders_for_admin(admin_client):
+    """Operations dashboard renders with 200 for allowlisted admin."""
+    response = admin_client.get("/dashboard/operations")
+    assert response.status_code == 200
+    assert b"Operations" in response.data
+    assert b"Today's Visits" in response.data
+
+
+def test_experiment_dashboard_blocks_unauthenticated(client):
+    response = client.get("/dashboard/experiment")
+    assert response.status_code == 302
+    assert "/admin/login" in response.location
+
+
+def test_operations_dashboard_blocks_unauthenticated(client):
+    response = client.get("/dashboard/operations")
+    assert response.status_code == 302
+    assert "/admin/login" in response.location
+
+
+def test_experiment_dashboard_blocks_participant_session(auth_client):
+    """A consented participant cannot access the Experiment dashboard."""
+    response = auth_client.get("/dashboard/experiment")
+    assert response.status_code == 302
+    assert "/admin/login" in response.location
+
+
+def test_experiment_dashboard_renders_with_no_data(admin_client):
+    """With an empty database, the Experiment dashboard still renders (no 500)."""
+    response = admin_client.get("/dashboard/experiment")
+    assert response.status_code == 200
+    assert b"0 <span" in response.data  # "0 / 50" enrollment count
+
+
+def test_experiment_dashboard_includes_export_buttons(admin_client):
+    """CSV and JSON export buttons are present on the Experiment dashboard."""
+    response = admin_client.get("/dashboard/experiment")
+    assert response.status_code == 200
+    assert b"Export CSV" in response.data
+    assert b"Export JSON" in response.data
+    assert b"format=csv" in response.data
+    assert b"format=json" in response.data
+
+
+def test_operations_dashboard_does_not_include_export_buttons(admin_client):
+    """Export buttons moved to the Experiment tab; Operations should no longer render them."""
+    response = admin_client.get("/dashboard/operations")
+    assert response.status_code == 200
+    assert b"Experiment Data Export" not in response.data
 
 
 def test_admin_export_redirects_when_unauthenticated(client):


### PR DESCRIPTION
## Description
Splits the admin dashboard into two tabs. **Experiment** (new default landing) is anchored on the IRB protocol's primary and secondary KPIs, with data broken down by experiment group, descriptive stats only, and binned histograms — suitable for a small-n (n=20–50) fixed-window study where live p-values would encourage peeking. **Operations** preserves the existing product-growth metrics unchanged for day-to-day health checks.

Also fixes a pre-existing post-OAuth redirect bug where admins signing in via Google were bounced to `/style-studio` (via Flask-Dance's default fallback to `/` and a lingering participant session cookie) instead of the dashboard.

## Related Issues
Closes #89

## Changes Made
- [x] `/dashboard` 302s to `/dashboard/experiment` (new default landing); `main.dashboard` preserved as a redirect stub so existing callers (e.g. `admin.login`) keep working
- [x] New `/dashboard/experiment` route + template with: enrollment strip, primary KPI (average star rating), secondary KPIs (viz per participant, session duration), experimental-group-only AI recommendation selection rate, and a data-completeness table
- [x] Existing dashboard moved to `/dashboard/operations` — identical metric cards and charts, only the sidebar is extracted into a shared partial, the title is renamed, and the Export buttons are removed
- [x] New `_experiment_metrics()` helper in `app/routes/main.py` — dedupes by `session_id` (matches the `/api/admin/export` rule), aggregates per-participant mean ratings, viz counts, summed durations, and AI-rec selection rate
- [x] Shared `_admin_sidebar.html` partial with active-tab highlighting and a Sign out link
- [x] Export CSV/JSON buttons moved from Operations to Experiment; the `/api/admin/export` endpoint itself is unchanged
- [x] Fix: `google_bp = make_google_blueprint(scope=["email"], redirect_to="admin.login")` — routes the post-OAuth callback back through `admin.login` so `admin_email` gets set and the user lands on the dashboard instead of `/`
- [x] No inferential statistics in the UI (no p-values, CIs, significance badges); no smoothed density curves — histograms only

## Testing & Verification
- `uv run ruff check .` → clean
- `uv run ruff format . --check` → clean
- `uv run pytest` → **83 passed** (7 new \`test_experiment_metrics.py\` unit tests + 9 new route tests in \`test_routes.py\` + all existing tests; \`test_dashboard_*\` updated to expect the 302)
- Manual: `/dashboard/experiment` renders with zero data (no 500); Operations tab still renders its charts; sign-out link works from both tabs

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reorganized admin dashboard into separate Experiment and Operations views with dedicated navigation sidebar.
  * Added comprehensive experiment metrics including enrollment tracking, rating distributions, visualization analysis, session duration analytics, AI recommendation rates, and data completeness indicators.
  * Introduced CSV and JSON export functionality for experiment data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->