### PR TITLE
feat(studio): strip control-vs-experimental branching

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -105,21 +105,6 @@ def get_genai_client():
         return None
 
 
-@main_bp.app_context_processor
-def inject_experiment_group():
-    sid = get_session_id()
-    experiment_group = None
-    if sid:
-        exp = (
-            ExperimentSession.query.filter_by(session_id=sid)
-            .order_by(ExperimentSession.started_at.desc())
-            .first()
-        )
-        if exp:
-            experiment_group = exp.experiment_group
-    return {"experiment_group": experiment_group}
-
-
 def log_visit(page_name):
     visit = Visit(
         page=page_name,
@@ -777,14 +762,6 @@ def recommend():
     import json
 
     sid = get_session_id()
-    exp = (
-        ExperimentSession.query.filter_by(session_id=sid)
-        .order_by(ExperimentSession.started_at.desc())
-        .first()
-    )
-    if not exp or exp.experiment_group != "experimental":
-        abort(403)
-
     photo_file = request.files.get("photo")
     if not photo_file:
         return jsonify({"error": "Missing photo"}), 400

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -117,61 +117,6 @@
     <!-- Custom JS -->
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 
-    {% if experiment_group %}
-    <script>
-        (function() {
-            let sessionId = sessionStorage.getItem('experiment_session_id');
-
-            function startHeartbeat() {
-                setInterval(() => {
-                    if (sessionId) {
-                        fetch('{{ url_for("main.api_session_ping") }}', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ session_id: sessionId })
-                        }).then(res => {
-                            if (!res.ok) {
-                                sessionId = null;
-                                sessionStorage.removeItem('experiment_session_id');
-                                initSession();
-                            }
-                        }).catch(err => console.warn('Ping failed:', err));
-                    }
-                }, 30000);
-            }
-
-            function initSession() {
-                fetch('{{ url_for("main.api_session_start") }}', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' }
-                })
-                .then(res => res.json())
-                .then(data => {
-                    if (data.session_id) {
-                        sessionId = data.session_id;
-                        sessionStorage.setItem('experiment_session_id', sessionId);
-                        startHeartbeat();
-                    }
-                })
-                .catch(err => console.warn('Session start failed:', err));
-            }
-
-            if (!sessionId) {
-                initSession();
-            } else {
-                startHeartbeat();
-            }
-
-            window.addEventListener('beforeunload', () => {
-                if (sessionId) {
-                    const data = JSON.stringify({ session_id: sessionId });
-                    navigator.sendBeacon('{{ url_for("main.api_session_end") }}', new Blob([data], { type: 'application/json' }));
-                }
-            });
-        })();
-    </script>
-    {% endif %}
-
     {% block extra_scripts %}{% endblock %}
 </body>
 

--- a/app/templates/style_studio.html
+++ b/app/templates/style_studio.html
@@ -75,11 +75,7 @@
             <div>
                 <h2 class="fw-bold mb-1">Pick a hairstyle</h2>
                 <p class="text-secondary mb-0">
-                    {% if experiment_group == 'experimental' %}
                     Styles with a ✨ are AI-recommended based on your photo. Hover for why.
-                    {% else %}
-                    Browse the full catalog and pick a style to visualize.
-                    {% endif %}
                 </p>
             </div>
             <div class="d-flex gap-2 flex-wrap" id="category-filters">
@@ -295,12 +291,11 @@
     // Module-level state
     const state = {
         photoFile: null,                // the File object
-        recommendations: null,          // array of {hairstyle_id, reasoning} for experimental
+        recommendations: null,          // array of {hairstyle_id, reasoning}
         selectedHairstyleId: null,
         selectedHairstyleName: null,
         selectedHairstyleDesc: null,
         aiPanelClickedId: null,
-        experimentGroup: "{{ experiment_group }}",  // rendered by Jinja
         generatedImageId: null,         // set after /api/generate
         generatedImageBlobUrl: null,    // set after /api/generate
     };
@@ -413,37 +408,30 @@
         imageInput.value = '';
     });
 
-    // --- Phase 1 → 2/3 ---
+    // --- Phase 1 → 2 (analyzing) → 3 (catalog) ---
     uploadContinueBtn.addEventListener("click", async () => {
         if (!state.photoFile) return;
 
-        // Documented decision: Control group skips analyzing phase entirely.
-        // This creates a time/anticipation confound, but is accepted per IRB and experimental design.
-        if (state.experimentGroup === "experimental") {
-            showPhase("analyzing");
-            analyzingErrorContainer.classList.add('d-none');
-            
-            try {
-                const fd = new FormData();
-                fd.append("photo", state.photoFile);
-                const res = await fetch("{{ url_for('main.recommend') }}", { method: "POST", body: fd });
-                
-                if (!res.ok) {
-                    const err = await res.json().catch(() => ({ error: "Unknown error" }));
-                    showAnalyzingError(err.error || "Failed to analyze photo");
-                    return;
-                }
-                
-                const data = await res.json();
-                state.recommendations = data.recommendations;
-                applyRecommendationHighlights();
-                showPhase("catalog");
-            } catch (e) {
-                showAnalyzingError("Network error. Please try again.");
+        showPhase("analyzing");
+        analyzingErrorContainer.classList.add('d-none');
+
+        try {
+            const fd = new FormData();
+            fd.append("photo", state.photoFile);
+            const res = await fetch("{{ url_for('main.recommend') }}", { method: "POST", body: fd });
+
+            if (!res.ok) {
+                const err = await res.json().catch(() => ({ error: "Unknown error" }));
+                showAnalyzingError(err.error || "Failed to analyze photo");
+                return;
             }
-        } else {
-            // Control: jump straight to catalog
+
+            const data = await res.json();
+            state.recommendations = data.recommendations;
+            applyRecommendationHighlights();
             showPhase("catalog");
+        } catch (e) {
+            showAnalyzingError("Network error. Please try again.");
         }
     });
 
@@ -458,7 +446,7 @@
 
     // --- Section 3: Catalog ---
     function applyRecommendationHighlights() {
-        if (!state.recommendations || state.experimentGroup !== "experimental") return;
+        if (!state.recommendations) return;
 
         const recById = new Map(state.recommendations.map(r => [r.hairstyle_id, r.reasoning]));
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -542,16 +542,6 @@ def test_api_recommend_unauthenticated_returns_401(client):
     assert response.status_code == 401
 
 
-def test_api_recommend_control_group_forbidden(auth_client):
-    """Control-group sessions get 403 on /api/recommend."""
-    response = auth_client.post(
-        "/api/recommend",
-        data={"photo": (make_test_image(), "test.jpg")},
-        content_type="multipart/form-data",
-    )
-    assert response.status_code == 403
-
-
 def test_api_recommend_missing_photo(experimental_client):
     client, _sid = experimental_client
     response = client.post(


### PR DESCRIPTION
## Description
The IRB experiment is over and every signed-in user goes through the AI-recommended flow, so the control-vs-experimental branching is dead weight that complicates upcoming work (2-stage observation pipeline, pre-gen visualizations, change-photo control). This PR strips the branching out of the studio template, the studio JS, and `/api/recommend`, and removes the now-orphaned 30s heartbeat block in [base.html](app/templates/base.html).

## Related Issues
Closes #103.

## Changes Made
- [x] [style_studio.html](app/templates/style_studio.html): drop `experimentGroup` from studio state; the upload handler always shows the analyzing phase and calls `/api/recommend`; the catalog header copy unconditionally references the ✨ badges; `applyRecommendationHighlights` no longer gates on experimental.
- [x] [main.py](app/routes/main.py): remove the `inject_experiment_group` app context processor and the experimental-only `abort(403)` gate at the top of `recommend()`. `sid = get_session_id()` stays — it still feeds the `Recommendation.session_id` insert until S2 drops the column.
- [x] [base.html](app/templates/base.html): delete the 30s `/api/session/ping` heartbeat `<script>` block. The `{% if experiment_group %}` conditional that gated it is gone with the context processor; the backend route handlers (`api_session_start` / `_ping` / `_end`) are scheduled for removal in Sa2.
- [x] [tests/test_routes.py](tests/test_routes.py): delete `test_api_recommend_control_group_forbidden`. It asserted the abort this PR removes; without the delete the suite fails on every push until S5 lands.

**Out of scope (deferred to other Sprint 6 issues):**
- Broader test-suite refactor — retiring the `experimental_client` fixture, repointing the remaining `/api/recommend` tests to a logged-in fixture: owned by S5.
- `api_session_*` route handlers + stale uploads cleanup: owned by Sa2.
- `ExperimentSession` model, admin/dashboard usages, schema cleanup: owned by Sa4 / S2.

## Testing & Verification
**Test suite:** `uv run pytest` → **81 passed, 0 failed**.

Manual verification of the acceptance criteria from #103, with a minted Flask session cookie pointed at the running dev server:
- [x] **All logged-in users see the analyzing phase + recommendation badges + reasoning panel.** Rendered `/style-studio` HTML for a logged-in user has the unconditional AI-recommended copy in the catalog header, and `state.experimentGroup` is gone from the JS state object.
- [x] **No reference to `experiment_group` remains in [style_studio.html](app/templates/style_studio.html).** `grep -n "experiment_group\|experimentGroup" app/templates/style_studio.html` returns nothing; same for the rendered DOM.
- [x] **`/api/recommend` returns 200 for any logged-in user (no 403):**
  - `POST /api/recommend` (logged-in, no photo) → **400 "Missing photo"** — proves the request got past `login_required` and past where the experimental abort used to be.
  - `POST /api/recommend` (unauthenticated) → **401** — `login_required` still gates it.
- [x] **Browser preview check.** Studio loads cleanly, no JS console errors, no periodic `/api/session/*` XHRs in the network log, Phase 1 (upload) renders correctly.
- [ ] **End-to-end Vertex AI generation** (analyzing → catalog with ✨ → generate) — needs real GCP creds + a face photo; not driveable headlessly. Reviewer should manually verify after a real Google sign-in.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works — kept the existing `test_api_recommend_unauthenticated_returns_401` and the `test_api_recommend_*` happy-path tests, which now collectively encode the new contract (login required, no experimental gate). Removed the now-invalid `test_api_recommend_control_group_forbidden`. Broader test-suite refactor deferred to S5.
- [x] My code follows the style guidelines of this project — `ruff` + `ruff format` pre-commit hooks passed
- [x] My changes generate no new warnings