### PR TITLE
feat(errors): persist server-side errors to a database

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -70,6 +70,7 @@ def create_app(config_class=Config):
     from app.routes.auth import auth_bp, google_bp
     from app.routes.main import main_bp
     from app.services.auth import current_user
+    from app.services.error_logging import install_error_logging
 
     app.register_blueprint(main_bp)
     # Flask-Dance owns /oauth/google and /oauth/google/authorized so the
@@ -78,5 +79,7 @@ def create_app(config_class=Config):
     app.register_blueprint(auth_bp)
 
     app.jinja_env.globals["current_user"] = current_user
+
+    install_error_logging(app)
 
     return app

--- a/app/models.py
+++ b/app/models.py
@@ -141,6 +141,29 @@ class Recommendation(db.Model):
     )
 
 
+class ErrorLog(db.Model):
+    """Persistent record of a server-side error.
+
+    Captures both uncaught exceptions (Flask logs them via app.logger before
+    rendering 500) and exceptions that view code caught and logged via
+    current_app.logger.error/.exception(). The DBErrorLogHandler writes one
+    row per logger record at ERROR level or above.
+    """
+
+    id = db.Column(db.Integer, primary_key=True)
+    timestamp = db.Column(
+        db.DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        index=True,
+    )
+    route = db.Column(db.String(255))
+    method = db.Column(db.String(10))
+    exception_class = db.Column(db.String(255))
+    message = db.Column(db.Text)
+    traceback = db.Column(db.Text)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+
+
 class Stylist(db.Model):
     """Represents a stylist in the directory."""
 

--- a/app/models.py
+++ b/app/models.py
@@ -148,6 +148,12 @@ class ErrorLog(db.Model):
     rendering 500) and exceptions that view code caught and logged via
     current_app.logger.error/.exception(). The DBErrorLogHandler writes one
     row per logger record at ERROR level or above.
+
+    PII warning: `message` is persisted verbatim from `record.getMessage()`,
+    so do not interpolate emails, names, photo bytes, or other user content
+    into `current_app.logger.error/.exception(...)` calls — they will land
+    in this table. Stick to identifiers (user_id, request id, etc.) and let
+    the route + exception_class + traceback carry the diagnostic signal.
     """
 
     id = db.Column(db.Integer, primary_key=True)
@@ -161,7 +167,11 @@ class ErrorLog(db.Model):
     exception_class = db.Column(db.String(255))
     message = db.Column(db.Text)
     traceback = db.Column(db.Text)
-    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
 
 
 class Stylist(db.Model):

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -25,12 +25,14 @@ from sqlalchemy.orm import joinedload
 
 from app.models import (
     Consent,
+    ErrorLog,
     ExperimentSession,
     GeneratedImage,
     Hairstyle,
     Rating,
     Recommendation,
     Stylist,
+    User,
     Visit,
     db,
 )
@@ -586,6 +588,14 @@ def operations_dashboard():
     visit_labels = list(mapped_vp.keys())
     visit_data = list(mapped_vp.values())
 
+    recent_errors = (
+        db.session.query(ErrorLog, User.email)
+        .outerjoin(User, ErrorLog.user_id == User.id)
+        .order_by(ErrorLog.timestamp.desc())
+        .limit(50)
+        .all()
+    )
+
     return render_template(
         "operations_dashboard.html",
         visits_today=visits_today,
@@ -603,6 +613,7 @@ def operations_dashboard():
         generations_last_week=last_week_arr,
         visit_labels=visit_labels,
         visit_data=visit_data,
+        recent_errors=recent_errors,
     )
 
 

--- a/app/services/error_logging.py
+++ b/app/services/error_logging.py
@@ -100,6 +100,15 @@ class DBErrorLogHandler(logging.Handler):
 
 
 def install_error_logging(app):
-    """Attach the DB error log handler to `app.logger`."""
-    handler = DBErrorLogHandler(app)
-    app.logger.addHandler(handler)
+    """Attach the DB error log handler to `app.logger`.
+
+    Idempotent — re-invoking `create_app` in the same process replaces any
+    prior `DBErrorLogHandler` rather than stacking. Replace (not skip),
+    because Flask's `app.logger` is keyed by `app.name`, so successive
+    `create_app()` calls share a single logger; a stale handler from a
+    torn-down app would otherwise commit against a defunct DB.
+    """
+    app.logger.handlers = [
+        h for h in app.logger.handlers if not isinstance(h, DBErrorLogHandler)
+    ]
+    app.logger.addHandler(DBErrorLogHandler(app))

--- a/app/services/error_logging.py
+++ b/app/services/error_logging.py
@@ -1,0 +1,105 @@
+"""Database-backed error logger.
+
+Persists server-side errors to the `error_log` table so they outlive Heroku's
+~1-week log retention. Implemented as a `logging.Handler` subclass attached to
+`app.logger` — captures both uncaught exceptions (Flask routes them through
+`app.log_exception()` -> `app.logger.error(..., exc_info=True)`) and view-caught
+exceptions where the developer called `current_app.logger.error/.exception(...)`.
+
+Privacy: this module never reads `request.files`, `request.data`,
+`request.form`, `request.get_json()`, or any other request body. Only the
+route path, HTTP method, exception class, the formatted log message, and the
+traceback string are persisted. `traceback.format_exc()` does not include
+local variable values, so user input is not captured through that channel.
+"""
+
+import logging
+import traceback as tb_module
+
+from flask import has_request_context, request, session
+
+
+class DBErrorLogHandler(logging.Handler):
+    """Logging handler that writes ERROR-level records to the `error_log` table.
+
+    Holds a reference to the app so we can open an app context for the DB
+    write (the handler may fire from places like teardown handlers where the
+    request context is unwinding).
+    """
+
+    def __init__(self, app, level=logging.ERROR):
+        super().__init__(level=level)
+        self.app = app
+
+    def emit(self, record):
+        """Write one log record as an `ErrorLog` row.
+
+        Errors during the write are swallowed — a failing logger must never
+        break the response cycle or trigger recursive logging.
+        """
+        try:
+            self._write_row(record)
+        except Exception:
+            # Last-resort: print to stderr via logging.Handler.handleError so
+            # we don't recurse through our own handler.
+            self.handleError(record)
+
+    def _write_row(self, record):
+        from app.models import ErrorLog, db
+
+        route, method, user_id = self._request_context_fields()
+        exc_class, tb_text = self._exception_fields(record)
+
+        entry = ErrorLog(
+            route=route,
+            method=method,
+            exception_class=exc_class,
+            message=record.getMessage(),
+            traceback=tb_text,
+            user_id=user_id,
+        )
+
+        # Use a fresh app context so the handler is safe to fire even when
+        # the originating request context is mid-teardown.
+        with self.app.app_context():
+            try:
+                db.session.add(entry)
+                db.session.commit()
+            except Exception:
+                db.session.rollback()
+                raise
+
+    @staticmethod
+    def _request_context_fields():
+        """Return (route, method, user_id) from the current request, if any."""
+        if not has_request_context():
+            return None, None, None
+        route = request.path
+        method = request.method
+        user_id = None
+        try:
+            user_id = session.get("user_id")
+        except Exception:
+            user_id = None
+        return route, method, user_id
+
+    @staticmethod
+    def _exception_fields(record):
+        """Return (exception_class, traceback_text) from a log record.
+
+        Both fields are best-effort: handled errors logged without
+        `exc_info=True` will have neither; uncaught exceptions and
+        `logger.exception(...)` calls will have both.
+        """
+        if record.exc_info:
+            exc_type, exc_value, exc_tb = record.exc_info
+            exc_class = exc_type.__name__ if exc_type else None
+            tb_text = "".join(tb_module.format_exception(exc_type, exc_value, exc_tb))
+            return exc_class, tb_text
+        return None, None
+
+
+def install_error_logging(app):
+    """Attach the DB error log handler to `app.logger`."""
+    handler = DBErrorLogHandler(app)
+    app.logger.addHandler(handler)

--- a/app/templates/operations_dashboard.html
+++ b/app/templates/operations_dashboard.html
@@ -152,6 +152,62 @@
                         </div>
                     </div>
                 </div>
+
+                <div class="col-12">
+                    <div class="card bg-card border border-secondary border-opacity-25 rounded-4 p-4 shadow-sm">
+                        <div class="d-flex justify-content-between align-items-center mb-4">
+                            <h5 class="text-white fw-bold mb-0">Recent Errors</h5>
+                            <span class="text-secondary text-sm">Last {{ recent_errors|length }} of latest 50</span>
+                        </div>
+                        {% if recent_errors %}
+                        <div class="table-responsive">
+                            <table class="table table-dark table-hover align-middle mb-0">
+                                <thead>
+                                    <tr class="text-secondary text-sm">
+                                        <th class="border-0">When</th>
+                                        <th class="border-0">Route</th>
+                                        <th class="border-0">Method</th>
+                                        <th class="border-0">Exception</th>
+                                        <th class="border-0">User</th>
+                                        <th class="border-0">Message</th>
+                                        <th class="border-0"></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for err, user_email in recent_errors %}
+                                    <tr>
+                                        <td class="text-secondary text-sm">{{ err.timestamp.strftime('%Y-%m-%d %H:%M:%S') if err.timestamp else '—' }}</td>
+                                        <td class="text-white text-sm font-monospace">{{ err.route or '—' }}</td>
+                                        <td class="text-secondary text-sm">{{ err.method or '—' }}</td>
+                                        <td class="text-warning text-sm font-monospace">{{ err.exception_class or '—' }}</td>
+                                        <td class="text-secondary text-sm">{{ user_email or '—' }}</td>
+                                        <td class="text-white text-sm" style="max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">{{ err.message or '—' }}</td>
+                                        <td>
+                                            {% if err.traceback %}
+                                            <button class="btn btn-sm btn-outline-secondary" type="button"
+                                                data-bs-toggle="collapse" data-bs-target="#tb-{{ err.id }}"
+                                                aria-expanded="false" aria-controls="tb-{{ err.id }}">
+                                                Traceback
+                                            </button>
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                    {% if err.traceback %}
+                                    <tr class="collapse" id="tb-{{ err.id }}">
+                                        <td colspan="7" class="bg-dark p-3">
+                                            <pre class="text-secondary text-sm mb-0" style="white-space: pre-wrap; word-break: break-word;">{{ err.traceback }}</pre>
+                                        </td>
+                                    </tr>
+                                    {% endif %}
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                        {% else %}
+                        <p class="text-secondary mb-0">No errors logged yet.</p>
+                        {% endif %}
+                    </div>
+                </div>
             </div>
 
         </div>

--- a/app/templates/operations_dashboard.html
+++ b/app/templates/operations_dashboard.html
@@ -157,7 +157,7 @@
                     <div class="card bg-card border border-secondary border-opacity-25 rounded-4 p-4 shadow-sm">
                         <div class="d-flex justify-content-between align-items-center mb-4">
                             <h5 class="text-white fw-bold mb-0">Recent Errors</h5>
-                            <span class="text-secondary text-sm">Last {{ recent_errors|length }} of latest 50</span>
+                            <span class="text-secondary text-sm">Showing {{ recent_errors|length }} (max 50)</span>
                         </div>
                         {% if recent_errors %}
                         <div class="table-responsive">

--- a/migrations/versions/e5f6a7b8c9d0_add_error_log_table.py
+++ b/migrations/versions/e5f6a7b8c9d0_add_error_log_table.py
@@ -29,7 +29,12 @@ def upgrade():
         sa.Column("message", sa.Text(), nullable=True),
         sa.Column("traceback", sa.Text(), nullable=True),
         sa.Column("user_id", sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(["user_id"], ["user.id"], name="fk_error_log_user_id"),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            name="fk_error_log_user_id",
+            ondelete="SET NULL",
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     with op.batch_alter_table("error_log") as batch_op:

--- a/migrations/versions/e5f6a7b8c9d0_add_error_log_table.py
+++ b/migrations/versions/e5f6a7b8c9d0_add_error_log_table.py
@@ -1,0 +1,42 @@
+"""add error_log table for server-side error logging
+
+Revision ID: e5f6a7b8c9d0
+Revises: a7b3c8e91d42
+Create Date: 2026-05-08 12:00:00.000000
+
+Persists server-side errors (uncaught exceptions + view-caught exceptions
+that called current_app.logger.error/.exception) so they survive Heroku's
+~1-week log retention. See issue #17.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e5f6a7b8c9d0"
+down_revision = "a7b3c8e91d42"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "error_log",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("timestamp", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("route", sa.String(length=255), nullable=True),
+        sa.Column("method", sa.String(length=10), nullable=True),
+        sa.Column("exception_class", sa.String(length=255), nullable=True),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column("traceback", sa.Text(), nullable=True),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], name="fk_error_log_user_id"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("error_log") as batch_op:
+        batch_op.create_index("ix_error_log_timestamp", ["timestamp"], unique=False)
+
+
+def downgrade():
+    with op.batch_alter_table("error_log") as batch_op:
+        batch_op.drop_index("ix_error_log_timestamp")
+    op.drop_table("error_log")

--- a/tests/test_error_logging.py
+++ b/tests/test_error_logging.py
@@ -169,6 +169,23 @@ def test_request_body_fields_are_not_persisted(app, client):
             )
 
 
+def test_install_error_logging_is_idempotent(app):
+    """Re-invoking `install_error_logging` must not stack handlers and must
+    leave exactly one DBErrorLogHandler bound to the current app."""
+    from app.services.error_logging import (
+        DBErrorLogHandler,
+        install_error_logging,
+    )
+
+    install_error_logging(app)
+    install_error_logging(app)
+    install_error_logging(app)
+
+    db_handlers = [h for h in app.logger.handlers if isinstance(h, DBErrorLogHandler)]
+    assert len(db_handlers) == 1
+    assert db_handlers[0].app is app
+
+
 def test_warning_level_does_not_create_row(app, client):
     """Handler is set at ERROR level; warnings/info should be ignored."""
     bp = Blueprint(f"warntest_{id(app)}", __name__)

--- a/tests/test_error_logging.py
+++ b/tests/test_error_logging.py
@@ -1,0 +1,189 @@
+"""Tests for the database-backed server-side error logger (issue #17)."""
+
+from unittest.mock import patch
+
+from flask import Blueprint
+
+from app.models import ErrorLog, db
+
+
+def _register_test_routes(app):
+    """Attach a fresh blueprint with a route that raises and a route that
+    catches-and-logs. Done once per test so each test gets its own routes.
+    """
+    bp = Blueprint(f"errortest_{id(app)}", __name__)
+
+    @bp.route("/__test/uncaught")
+    def uncaught():
+        raise RuntimeError("kaboom uncaught")
+
+    @bp.route("/__test/caught")
+    def caught():
+        try:
+            raise ValueError("kaboom caught")
+        except ValueError:
+            from flask import current_app
+
+            current_app.logger.exception("handled value error")
+            return "ok", 200
+
+    @bp.route("/__test/log_no_exc")
+    def log_no_exc():
+        from flask import current_app
+
+        current_app.logger.error("plain error message, no exc_info")
+        return "ok", 200
+
+    app.register_blueprint(bp)
+
+
+def test_uncaught_exception_writes_error_log_row(app, client):
+    _register_test_routes(app)
+    app.config["TESTING"] = False  # let Flask invoke the error handler chain
+
+    client.get("/__test/uncaught")
+
+    with app.app_context():
+        rows = ErrorLog.query.all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.route == "/__test/uncaught"
+        assert row.method == "GET"
+        assert row.exception_class == "RuntimeError"
+        assert "kaboom uncaught" in (row.message or "") or "kaboom uncaught" in (
+            row.traceback or ""
+        )
+        assert row.traceback is not None
+        assert "RuntimeError" in row.traceback
+
+
+def test_caught_exception_logged_via_logger_exception_writes_row(app, client):
+    """Developer-handled errors that flash a message should still be logged
+    when the developer calls current_app.logger.exception(...)."""
+    _register_test_routes(app)
+
+    response = client.get("/__test/caught")
+    assert response.status_code == 200  # caught + flashed-style behavior
+
+    with app.app_context():
+        rows = ErrorLog.query.all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.route == "/__test/caught"
+        assert row.exception_class == "ValueError"
+        assert row.traceback is not None
+        assert "ValueError" in row.traceback
+        assert row.message == "handled value error"
+
+
+def test_logger_error_without_exc_info_records_route_and_message(app, client):
+    """Plain logger.error('foo') without exc_info still records route +
+    message; traceback and exception_class are NULL."""
+    _register_test_routes(app)
+
+    client.get("/__test/log_no_exc")
+
+    with app.app_context():
+        rows = ErrorLog.query.all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.route == "/__test/log_no_exc"
+        assert row.message == "plain error message, no exc_info"
+        assert row.exception_class is None
+        assert row.traceback is None
+
+
+def test_db_failure_does_not_break_response(app, client):
+    """If the DB write fails, the handler must swallow the failure so the
+    response cycle isn't broken and we don't recurse."""
+    _register_test_routes(app)
+    app.config["TESTING"] = False
+
+    real_commit = db.session.commit
+
+    def _exploding_commit():
+        # Roll back so the session can be reused after; then raise.
+        db.session.rollback()
+        raise RuntimeError("simulated DB outage")
+
+    with patch.object(db.session, "commit", side_effect=_exploding_commit):
+        # If the handler doesn't swallow, this call will raise out of the
+        # test client and fail the test.
+        response = client.get("/__test/uncaught")
+
+    # 500 from the original RuntimeError, not from the logger
+    assert response.status_code == 500
+
+    # restore for any teardown that needs to commit
+    db.session.commit = real_commit
+
+
+def test_authenticated_user_id_is_recorded(app, admin_client):
+    _register_test_routes(app)
+
+    admin_client.get("/__test/caught")
+
+    with app.app_context():
+        row = ErrorLog.query.first()
+        assert row is not None
+        assert row.user_id is not None
+
+
+def test_unauthenticated_user_id_is_null(app, client):
+    _register_test_routes(app)
+
+    client.get("/__test/caught")
+
+    with app.app_context():
+        row = ErrorLog.query.first()
+        assert row is not None
+        assert row.user_id is None
+
+
+def test_request_body_fields_are_not_persisted(app, client):
+    """Privacy hygiene: form data, JSON body, and uploaded files must never
+    end up in any column. We don't read them in the handler — verify by
+    posting sensitive-looking content and confirming none of it appears.
+    """
+    bp = Blueprint(f"privacytest_{id(app)}", __name__)
+
+    @bp.route("/__test/sensitive", methods=["POST"])
+    def sensitive():
+        raise RuntimeError("boom")
+
+    app.register_blueprint(bp)
+    app.config["TESTING"] = False
+
+    secret = "DO_NOT_LOG_THIS_PHOTO_BYTES_OR_FORM_VALUE_xyz123"
+    client.post(
+        "/__test/sensitive",
+        data={"observation": secret, "secret_field": secret},
+    )
+
+    with app.app_context():
+        row = ErrorLog.query.first()
+        assert row is not None
+        for field in (row.message, row.traceback, row.route, row.method):
+            assert secret not in (field or ""), (
+                f"sensitive value leaked into ErrorLog field: {field!r}"
+            )
+
+
+def test_warning_level_does_not_create_row(app, client):
+    """Handler is set at ERROR level; warnings/info should be ignored."""
+    bp = Blueprint(f"warntest_{id(app)}", __name__)
+
+    @bp.route("/__test/warn")
+    def warn():
+        from flask import current_app
+
+        current_app.logger.warning("just a warning")
+        current_app.logger.info("just an info")
+        return "ok", 200
+
+    app.register_blueprint(bp)
+
+    client.get("/__test/warn")
+
+    with app.app_context():
+        assert ErrorLog.query.count() == 0


### PR DESCRIPTION
## Summary

- Adds an `ErrorLog` model + Alembic migration so server-side errors survive Heroku's ~1-week log retention.
- Captures both uncaught exceptions and view-caught errors logged via `current_app.logger.error/.exception(...)` — implemented as a `logging.Handler` subclass attached to `app.logger`, so it observes records without interfering with `errorhandler(404)` or other error-handling behavior.
- Adds a "Recent Errors" section to the Operations dashboard (admin-only) with click-to-expand tracebacks.

Closes #17.

## Why a `logging.Handler` (vs. `errorhandler(Exception)` or the `got_request_exception` signal)

- `errorhandler(Exception)` is greedy — it catches everything including `HTTPException` 4xx, easy to subtly break the existing 404 page (the issue itself flags this risk).
- `got_request_exception` only fires for **un**handled exceptions, so it would miss the case the issue cares about most: a developer-caught error that flashes a friendly message but is still a real server fault we need to know about.
- `logging.Handler` attached to `app.logger` is purely additive: Flask's built-in `app.log_exception()` already routes uncaught exceptions through `app.logger.error(..., exc_info=True)`, and existing `current_app.logger.error/.exception(...)` calls inside `except` blocks are picked up too — zero changes to existing view code.

## Privacy hygiene

The handler never reads `request.files`, `request.data`, `request.form`, or `request.get_json()`. Only `route`, `method`, `exception_class`, the log message, the formatted traceback, and `user_id` (from `session[\"user_id\"]`) are persisted. `traceback.format_exc()` does not include local variable values, so user input does not leak through that channel.

## Test plan

- [x] `uv run pytest` — full suite (90 passed)
- [x] `flask db upgrade` from a clean SQLite DB — migrations run cleanly through to the new revision; `flask db downgrade` reverses cleanly
- [x] Tests cover: uncaught-exception logging, caught-exception logging via `logger.exception`, plain `logger.error` without `exc_info`, DB-write failure does not break the response cycle, authenticated user_id captured, unauthenticated user_id is NULL, request body never persisted, warnings/info ignored
- [x] Rendered the Operations dashboard with a seeded `ErrorLog` row and confirmed the new "Recent Errors" panel renders timestamp, route, method, exception class, user email, message, and click-to-expand traceback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error logging system: Server errors now captured and persisted with timestamp, route, method, and exception details.
  * Operations Dashboard: New "Recent Errors" card displays recent server errors for monitoring and debugging purposes.

* **Tests**
  * Comprehensive test coverage added for error logging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->