### PR TITLE
chore(footer): wire Support link and drop study-era code comments

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -89,8 +89,8 @@ def _day_of_week(date_column):
 def get_genai_client():
     """Return a google.genai Client configured for Vertex AI.
 
-    Required by IRB Section 4.1 to ensure Zero Data Retention (ZDR).
-    Do not replace with Gemini Developer API.
+    Vertex AI mode gives us Zero Data Retention (ZDR); do not replace with
+    the Gemini Developer API.
     """
     project = current_app.config.get("GOOGLE_CLOUD_PROJECT")
     location = current_app.config.get("GOOGLE_CLOUD_LOCATION", "us-central1")
@@ -123,11 +123,6 @@ def index():
     if sid and Consent.query.filter_by(session_id=sid).first():
         return redirect(url_for("main.style_studio"))
     return render_template("landing.html")
-
-
-# ---------------------------------------------------------------------------
-# Consent (minimal PR1 stub — issue #4 replaces this with IRB-verbatim content)
-# ---------------------------------------------------------------------------
 
 
 @main_bp.route("/consent", methods=["GET"])
@@ -562,10 +557,10 @@ def export_data():
 def result(image_id=None):
     """Render the result page for an AI hairstyle generation.
 
-    The generated image bytes are never persisted server-side (IRB Section 6.1);
-    the client holds the only copy in sessionStorage after /api/generate streams
-    the WebP back. This view renders metadata only (hairstyle name, rating state);
-    the template hydrates the <img> src from sessionStorage on load.
+    The generated image bytes are never persisted server-side; the client holds
+    the only copy in sessionStorage after /api/generate streams the WebP back.
+    This view renders metadata only (hairstyle name, rating state); the template
+    hydrates the <img> src from sessionStorage on load.
     """
     log_visit("Results Page")
     sid = get_session_id()

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -103,7 +103,8 @@
                         <a href="{{ url_for('main.privacy') }}"
                             class="text-secondary text-decoration-none small fw-semibold">Privacy</a>
                         <a href="{{ url_for('main.terms') }}" class="text-secondary text-decoration-none small fw-semibold">Terms</a>
-                        <a href="#" class="text-secondary text-decoration-none small fw-semibold">Support</a>
+                        <a href="mailto:rfagya27@colby.edu?subject=TrueHair%20AI%20Support%20Request"
+                            class="text-secondary text-decoration-none small fw-semibold">Support</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Description
Wires the footer Support link to the team support inbox and rewords or removes three IRB-era code comments now that the study has concluded. The IRB Section 4.1 docstring on `get_genai_client()` is reframed as a product note, the "(IRB Section 6.1)" parenthetical in `result()`'s docstring is dropped, and the "Consent (minimal PR1 stub …)" banner above `/consent` is removed.

The other items originally listed under issue #8's misc cleanup are already handled or out of scope here:

- `app/routes/admin.py` no longer exists — the auth-foundation PR (#107) replaced it with `app/routes/auth.py`, so the "study protocol" docstring is gone.
- [admin_unauthorized.html](app/templates/admin_unauthorized.html) was rechecked post-auth-refactor — copy is already clean (no IRB references, links to `auth.logout`).

The remaining `IRB`/`consent` references in the repo (in [landing.html](app/templates/landing.html), [privacy.html](app/templates/privacy.html), [terms.html](app/templates/terms.html), [consent.html](app/templates/consent.html), the `/consent` route, the `Consent` model, etc.) are tracked under the dedicated rewrite/removal issues in Sprint 6 and are intentionally not touched here.

## Related Issues
Closes #8.

## Changes Made
- [x] [base.html](app/templates/base.html): footer Support link `href="#"` → `mailto:rfagya27@colby.edu?subject=TrueHair AI Support Request`. Privacy and Terms links were already wired correctly.
- [x] [main.py](app/routes/main.py) `get_genai_client()` docstring: drop "Required by IRB Section 4.1" framing; keep the practical "Vertex AI gives us ZDR; do not replace with the Gemini Developer API" guidance.
- [x] [main.py](app/routes/main.py) `result()` docstring: drop the "(IRB Section 6.1)" parenthetical; the "image bytes never persisted server-side" statement stands on its own.
- [x] [main.py](app/routes/main.py): remove the `# Consent (minimal PR1 stub — issue #4 replaces this with IRB-verbatim content)` banner above `/consent`.

## Testing & Verification
- `uv run pytest -x -q` — 81 passed.
- Manual: load any page, click the footer Support link → opens email composer addressed to `rfagya27@colby.edu` with subject "TrueHair AI Support Request".
- Manual: `rg -i "IRB" app/routes/main.py` returns no hits.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- N/A: pure copy/comment cleanup; no behavior change. Existing 81 tests pass. -->
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on Zero Data Retention (ZDR) capabilities
  * Documented that generated images are not persisted server-side

* **Bug Fixes**
  * Fixed Support link to enable direct email communication with predefined subject line

<!-- end of auto-generated comment: release notes by coderabbit.ai -->