### PR TITLE
Pre-generate top 2 recommended visualizations + gthread workers (closes #105)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn run:app --timeout 120 --access-logformat '%(m)s %(U)s %(s)s %(b)s %(L)s %({x-request-id}i)s'
+web: gunicorn run:app --timeout 120 --workers 1 --threads 8 --worker-class gthread --access-logformat '%(m)s %(U)s %(s)s %(b)s %(L)s %({x-request-id}i)s'
 release: flask db upgrade && python seed_hairstyles.py && python seed_stylists.py

--- a/app/templates/style_studio.html
+++ b/app/templates/style_studio.html
@@ -630,18 +630,29 @@
             state.recommendations = data.recommendations;
             applyRecommendationHighlights();
             showPhase("catalog");
+            // Pre-generate previews for the top recommendations only. Vertex AI
+            // image-edit reliably 429s above ~2 concurrent calls per project,
+            // so we cap fan-out at PREGEN_LIMIT and let the rest fall through
+            // to live /api/generate when the user actually clicks Generate.
+            preGenerateTopRecommendations(state.recommendations);
         } catch (e) {
             showAnalyzingError("Network error. Please try again.");
         }
     });
 
-    // --- Lazy hover-triggered pre-generation ---
-    // We deliberately do NOT fan out generations on rec-success. The first
-    // hover/focus on a recommended card kicks off a single /api/generate; the
-    // result is cached so subsequent hovers and the eventual Generate-button
-    // click reuse it instantly. The catalog appears immediately, and the only
-    // wait the user sees is the spinner over the AI panel's thumbnail when
-    // they choose to inspect a specific recommendation.
+    // --- Pre-generation for top recommendations ---
+    // Capped at PREGEN_LIMIT styles. Vertex AI image-edit is flaky under
+    // higher parallelism (text-only fallbacks, 429 RESOURCE_EXHAUSTED), and 2
+    // concurrent calls is the largest fan-out we've measured to land
+    // reliably. Recommendations beyond the cap show the catalog placeholder
+    // in the AI panel and trigger a live generation when the user clicks the
+    // Generate button.
+    const PREGEN_LIMIT = 2;
+    function preGenerateTopRecommendations(recommendations) {
+        if (!state.photoFile || !recommendations?.length) return;
+        recommendations.slice(0, PREGEN_LIMIT).forEach(r => preGenerateOne(r.hairstyle_id));
+    }
+
     function preGenerateOne(hairstyleId) {
         const idStr = String(hairstyleId);
         const existing = state.preGenerated.get(idStr);
@@ -782,10 +793,15 @@
         aiPanelContent.classList.add('d-flex');
         state.aiPanelCurrentId = id;
 
-        // Kick off (or reuse) pre-generation for this style. If it's already
-        // resolved we can swap the thumb in synchronously; otherwise show a
-        // spinner over the catalog placeholder until the call lands.
-        const entry = preGenerateOne(id);
+        // Read-only cache lookup: only the top PREGEN_LIMIT recommendations
+        // get pre-generated, so most hovers fall through to the catalog
+        // placeholder. Don't kick off a generation here — that would
+        // re-introduce the 429 storm we hit when fanning out to all 4 recs.
+        const entry = state.preGenerated.get(id);
+        if (!entry) {
+            setPanelSpinner(false);
+            return;
+        }
         if (entry.result) {
             setPanelSpinner(false);
             if (entry.result.ok) aiPanelThumb.src = entry.result.blobUrl;

--- a/app/templates/style_studio.html
+++ b/app/templates/style_studio.html
@@ -153,13 +153,6 @@
                         style="background: var(--th-yellow); color: #000; padding: 4px 10px; border-radius: 999px; font-size: 0.7rem; font-weight: 700; z-index: 10;">
                         ✨ Recommended
                     </div>
-                    <!-- Pre-generation spinner: shown while a preview for this recommended style is being generated. -->
-                    <div class="pregen-spinner position-absolute top-50 start-50 translate-middle d-none"
-                        aria-hidden="true" style="z-index: 9;">
-                        <div class="spinner-border text-yellow" role="status" style="width: 2rem; height: 2rem;">
-                            <span class="visually-hidden">Generating preview...</span>
-                        </div>
-                    </div>
                     <!-- Selection check: hidden by default -->
                     <div class="selection-indicator position-absolute top-0 end-0 m-3 bg-warning text-dark rounded-circle d-none align-items-center justify-content-center"
                         style="width: 24px; height: 24px; z-index: 10;">
@@ -186,7 +179,15 @@
                             </div>
 
                             <div id="ai-panel-content" class="d-none align-items-center gap-3 w-100">
-                                <img id="ai-panel-thumb" src="" alt="" class="rounded-3 flex-shrink-0" style="width: 64px; height: 64px; object-fit: cover;">
+                                <div class="position-relative flex-shrink-0" style="width: 64px; height: 64px;">
+                                    <img id="ai-panel-thumb" src="" alt="" class="rounded-3 w-100 h-100" style="object-fit: cover;">
+                                    <div id="ai-panel-spinner" class="position-absolute top-0 start-0 w-100 h-100 d-none align-items-center justify-content-center rounded-3"
+                                        style="background: rgba(0, 0, 0, 0.55); backdrop-filter: blur(2px);" aria-hidden="true">
+                                        <div class="spinner-border text-yellow" role="status" style="width: 1.4rem; height: 1.4rem; border-width: 2px;">
+                                            <span class="visually-hidden">Generating preview...</span>
+                                        </div>
+                                    </div>
+                                </div>
                                 <div class="flex-grow-1" style="min-width: 0;">
                                     <div class="d-flex align-items-center gap-2 mb-1">
                                         <span style="color: var(--th-yellow); font-size: 0.9rem;">✨</span>
@@ -396,6 +397,7 @@
     const aiPanelEmpty = document.getElementById('ai-panel-empty');
     const aiPanelContent = document.getElementById('ai-panel-content');
     const aiPanelThumb = document.getElementById('ai-panel-thumb');
+    const aiPanelSpinner = document.getElementById('ai-panel-spinner');
     const aiPanelName = document.getElementById('ai-panel-name');
     const aiPanelReasoning = document.getElementById('ai-panel-reasoning');
     
@@ -628,29 +630,25 @@
             state.recommendations = data.recommendations;
             applyRecommendationHighlights();
             showPhase("catalog");
-            // Fan out parallel pre-generations so thumbnails are ready when the
-            // user hovers a recommended card. Browsers cap connections per
-            // origin; recs are 2-4 server-side so a flat fan-out is safe.
-            preGenerateRecommendations(state.recommendations);
         } catch (e) {
             showAnalyzingError("Network error. Please try again.");
         }
     });
 
-    // --- Pre-generation fan-out (B10) ---
-    function setCardSpinner(hairstyleId, show) {
-        const item = document.querySelector(`.hairstyle-item[data-id="${hairstyleId}"]`);
-        if (!item) return;
-        const spinner = item.querySelector('.pregen-spinner');
-        if (!spinner) return;
-        spinner.classList.toggle('d-none', !show);
-    }
-
+    // --- Lazy hover-triggered pre-generation ---
+    // We deliberately do NOT fan out generations on rec-success. The first
+    // hover/focus on a recommended card kicks off a single /api/generate; the
+    // result is cached so subsequent hovers and the eventual Generate-button
+    // click reuse it instantly. The catalog appears immediately, and the only
+    // wait the user sees is the spinner over the AI panel's thumbnail when
+    // they choose to inspect a specific recommendation.
     function preGenerateOne(hairstyleId) {
         const idStr = String(hairstyleId);
-        setCardSpinner(idStr, true);
+        const existing = state.preGenerated.get(idStr);
+        if (existing) return existing;
 
-        const promise = (async () => {
+        const entry = { promise: null, result: null };
+        entry.promise = (async () => {
             try {
                 const fd = new FormData();
                 fd.append("photo", state.photoFile);
@@ -669,28 +667,17 @@
                 }
                 const blob = await res.blob();
                 const blobUrl = URL.createObjectURL(blob);
-
-                // If the panel is currently displaying this item (via hover or
-                // click), upgrade the thumb to the freshly-generated preview.
-                if (state.aiPanelCurrentId === idStr) {
-                    aiPanelThumb.src = blobUrl;
-                }
                 return { ok: true, blob, blobUrl, generatedImageId };
             } catch (e) {
                 return { ok: false, error: e };
-            } finally {
-                setCardSpinner(idStr, false);
             }
-        })();
+        })().then(result => {
+            entry.result = result;
+            return result;
+        });
 
-        state.preGenerated.set(idStr, { promise });
-        return promise;
-    }
-
-    function preGenerateRecommendations(recommendations) {
-        if (!state.photoFile || !recommendations?.length) return;
-        // Cap at 4 parallel fetches; recs are already capped at 4 server-side.
-        recommendations.slice(0, 4).forEach(r => preGenerateOne(r.hairstyle_id));
+        state.preGenerated.set(idStr, entry);
+        return entry;
     }
 
     function clearPreGenerated() {
@@ -701,7 +688,6 @@
             });
         }
         state.preGenerated.clear();
-        document.querySelectorAll('.pregen-spinner').forEach(el => el.classList.add('d-none'));
     }
 
     function showAnalyzingError(msg) {
@@ -764,6 +750,11 @@
         });
     });
 
+    function setPanelSpinner(show) {
+        aiPanelSpinner.classList.toggle('d-none', !show);
+        aiPanelSpinner.classList.toggle('d-flex', show);
+    }
+
     function showAIPanelForItem(item) {
         const card = item.querySelector('.style-card');
         if (!card.classList.contains('is-recommended')) return;
@@ -772,10 +763,6 @@
         const id = item.dataset.id;
         const img = item.querySelector('img');
 
-        // Show the catalog image as a placeholder, then upgrade to the
-        // pre-generated thumbnail once it's ready (or immediately if it's already
-        // resolved). The .then guard skips updates after the panel has moved on
-        // to a different item.
         aiPanelThumb.src = img ? img.src : '';
         aiPanelThumb.alt = name;
         aiPanelName.textContent = name;
@@ -785,12 +772,20 @@
         aiPanelContent.classList.add('d-flex');
         state.aiPanelCurrentId = id;
 
-        const cached = state.preGenerated.get(id);
-        if (cached) {
-            cached.promise.then(result => {
-                if (result?.ok && state.aiPanelCurrentId === id) {
-                    aiPanelThumb.src = result.blobUrl;
-                }
+        // Kick off (or reuse) pre-generation for this style. If it's already
+        // resolved we can swap the thumb in synchronously; otherwise show a
+        // spinner over the catalog placeholder until the call lands.
+        const entry = preGenerateOne(id);
+        if (entry.result) {
+            setPanelSpinner(false);
+            if (entry.result.ok) aiPanelThumb.src = entry.result.blobUrl;
+        } else {
+            setPanelSpinner(true);
+            entry.promise.then(result => {
+                // Skip if the panel has moved on to a different item.
+                if (state.aiPanelCurrentId !== id) return;
+                setPanelSpinner(false);
+                if (result?.ok) aiPanelThumb.src = result.blobUrl;
             });
         }
     }
@@ -799,6 +794,7 @@
         aiPanelContent.classList.add('d-none');
         aiPanelContent.classList.remove('d-flex');
         aiPanelEmpty.classList.remove('d-none');
+        setPanelSpinner(false);
         state.aiPanelCurrentId = null;
     }
 

--- a/app/templates/style_studio.html
+++ b/app/templates/style_studio.html
@@ -717,6 +717,16 @@
                 item.dataset.reasoning = reasoning;
             }
         });
+
+        // Reorder so recommended cards lead the catalog in recommendation order.
+        const grid = document.getElementById("hairstyle-grid");
+        let insertPos = 0;
+        state.recommendations.forEach(rec => {
+            const item = grid.querySelector(`.hairstyle-item[data-id="${rec.hairstyle_id}"]`);
+            if (!item) return;
+            grid.insertBefore(item, grid.children[insertPos]);
+            insertPos++;
+        });
     }
 
     function setFilterButtonState(activeButton) {

--- a/app/templates/style_studio.html
+++ b/app/templates/style_studio.html
@@ -356,7 +356,9 @@
         aiPanelCurrentId: null,         // currently displayed item id (hover or click)
         generatedImageId: null,         // set after /api/generate
         generatedImageBlobUrl: null,    // set after /api/generate
-        // hairstyle_id (string) -> { promise: Promise<{ok, blob, blobUrl, generatedImageId} | {ok:false, error}> }
+        // hairstyle_id (string) -> { promise: Promise<Result>, result: Result | null }
+        // where Result = { ok: true, blob, blobUrl, generatedImageId } | { ok: false, error }.
+        // result mirrors the resolved promise so re-hovers settle without a microtask round-trip.
         // blobUrl is owned by the map entry until taken (see Generate handler).
         preGenerated: new Map(),
     };
@@ -466,6 +468,11 @@
     function handleFileSelection(file) {
         state.photoFile = file;
         state.observation = null;
+        // Drop any cache entries from the previous photo — they were generated
+        // against a different selfie and would otherwise leak into hover/Generate
+        // for any hairstyle id that overlaps between the two recommendation
+        // sets. Mirrors the analyzeRequestId guard used for /api/analyze-photo.
+        clearPreGenerated();
 
         const reader = new FileReader();
         reader.onload = function (e) {
@@ -680,6 +687,10 @@
                 const blobUrl = URL.createObjectURL(blob);
                 return { ok: true, blob, blobUrl, generatedImageId };
             } catch (e) {
+                // Surface pre-gen failures in DevTools so we have *some* signal
+                // when Vertex 429s or Gemini returns text-only — the user-visible
+                // fallback (live /api/generate on Generate click) is silent.
+                console.warn(`Pre-generation failed for hairstyle_id=${idStr}:`, e);
                 return { ok: false, error: e };
             }
         })().then(result => {
@@ -730,13 +741,19 @@
         });
 
         // Reorder so recommended cards lead the catalog in recommendation order.
+        // Anchor inserts on the first .hairstyle-item child (rather than
+        // grid.children[insertPos]) so a future header/divider as a direct
+        // child of #hairstyle-grid wouldn't get bumped into the wrong slot.
         const grid = document.getElementById("hairstyle-grid");
-        let insertPos = 0;
+        const firstItem = () => grid.querySelector(".hairstyle-item");
+        let anchor = firstItem();
         state.recommendations.forEach(rec => {
             const item = grid.querySelector(`.hairstyle-item[data-id="${rec.hairstyle_id}"]`);
-            if (!item) return;
-            grid.insertBefore(item, grid.children[insertPos]);
-            insertPos++;
+            if (!item || item === anchor) {
+                if (item === anchor) anchor = item.nextElementSibling;
+                return;
+            }
+            grid.insertBefore(item, anchor);
         });
     }
 

--- a/app/templates/style_studio.html
+++ b/app/templates/style_studio.html
@@ -153,6 +153,13 @@
                         style="background: var(--th-yellow); color: #000; padding: 4px 10px; border-radius: 999px; font-size: 0.7rem; font-weight: 700; z-index: 10;">
                         ✨ Recommended
                     </div>
+                    <!-- Pre-generation spinner: shown while a preview for this recommended style is being generated. -->
+                    <div class="pregen-spinner position-absolute top-50 start-50 translate-middle d-none"
+                        aria-hidden="true" style="z-index: 9;">
+                        <div class="spinner-border text-yellow" role="status" style="width: 2rem; height: 2rem;">
+                            <span class="visually-hidden">Generating preview...</span>
+                        </div>
+                    </div>
                     <!-- Selection check: hidden by default -->
                     <div class="selection-indicator position-absolute top-0 end-0 m-3 bg-warning text-dark rounded-circle d-none align-items-center justify-content-center"
                         style="width: 24px; height: 24px; z-index: 10;">
@@ -345,8 +352,12 @@
         selectedHairstyleName: null,
         selectedHairstyleDesc: null,
         aiPanelClickedId: null,
+        aiPanelCurrentId: null,         // currently displayed item id (hover or click)
         generatedImageId: null,         // set after /api/generate
         generatedImageBlobUrl: null,    // set after /api/generate
+        // hairstyle_id (string) -> { promise: Promise<{ok, blob, blobUrl, generatedImageId} | {ok:false, error}> }
+        // blobUrl is owned by the map entry until taken (see Generate handler).
+        preGenerated: new Map(),
     };
 
     // --- DOM Elements ---
@@ -489,6 +500,7 @@
         placeholder.classList.remove('d-none');
         imageInput.value = '';
         resetObservationUI();
+        clearPreGenerated();
     }
 
     removeBtn.addEventListener('click', clearPhoto);
@@ -616,10 +628,81 @@
             state.recommendations = data.recommendations;
             applyRecommendationHighlights();
             showPhase("catalog");
+            // Fan out parallel pre-generations so thumbnails are ready when the
+            // user hovers a recommended card. Browsers cap connections per
+            // origin; recs are 2-4 server-side so a flat fan-out is safe.
+            preGenerateRecommendations(state.recommendations);
         } catch (e) {
             showAnalyzingError("Network error. Please try again.");
         }
     });
+
+    // --- Pre-generation fan-out (B10) ---
+    function setCardSpinner(hairstyleId, show) {
+        const item = document.querySelector(`.hairstyle-item[data-id="${hairstyleId}"]`);
+        if (!item) return;
+        const spinner = item.querySelector('.pregen-spinner');
+        if (!spinner) return;
+        spinner.classList.toggle('d-none', !show);
+    }
+
+    function preGenerateOne(hairstyleId) {
+        const idStr = String(hairstyleId);
+        setCardSpinner(idStr, true);
+
+        const promise = (async () => {
+            try {
+                const fd = new FormData();
+                fd.append("photo", state.photoFile);
+                fd.append("hairstyle_id", idStr);
+                if (state.observation) fd.append("observation", state.observation);
+
+                const res = await fetch("{{ url_for('main.generate') }}", { method: "POST", body: fd });
+                if (!res.ok) {
+                    const err = await res.json().catch(() => ({}));
+                    throw new Error(err.error || "Pre-generation failed");
+                }
+                const idHeader = res.headers.get("X-Generated-Image-Id");
+                const generatedImageId = parseInt(idHeader, 10);
+                if (!Number.isFinite(generatedImageId)) {
+                    throw new Error("Server did not return a valid image id");
+                }
+                const blob = await res.blob();
+                const blobUrl = URL.createObjectURL(blob);
+
+                // If the panel is currently displaying this item (via hover or
+                // click), upgrade the thumb to the freshly-generated preview.
+                if (state.aiPanelCurrentId === idStr) {
+                    aiPanelThumb.src = blobUrl;
+                }
+                return { ok: true, blob, blobUrl, generatedImageId };
+            } catch (e) {
+                return { ok: false, error: e };
+            } finally {
+                setCardSpinner(idStr, false);
+            }
+        })();
+
+        state.preGenerated.set(idStr, { promise });
+        return promise;
+    }
+
+    function preGenerateRecommendations(recommendations) {
+        if (!state.photoFile || !recommendations?.length) return;
+        // Cap at 4 parallel fetches; recs are already capped at 4 server-side.
+        recommendations.slice(0, 4).forEach(r => preGenerateOne(r.hairstyle_id));
+    }
+
+    function clearPreGenerated() {
+        // Revoke owned blob URLs once the in-flight promises settle.
+        for (const entry of state.preGenerated.values()) {
+            entry.promise.then(result => {
+                if (result?.ok && result.blobUrl) URL.revokeObjectURL(result.blobUrl);
+            });
+        }
+        state.preGenerated.clear();
+        document.querySelectorAll('.pregen-spinner').forEach(el => el.classList.add('d-none'));
+    }
 
     function showAnalyzingError(msg) {
         analyzingErrorMessage.textContent = msg;
@@ -686,7 +769,13 @@
         if (!card.classList.contains('is-recommended')) return;
         const reasoning = item.dataset.reasoning || '';
         const name = item.dataset.name || '';
+        const id = item.dataset.id;
         const img = item.querySelector('img');
+
+        // Show the catalog image as a placeholder, then upgrade to the
+        // pre-generated thumbnail once it's ready (or immediately if it's already
+        // resolved). The .then guard skips updates after the panel has moved on
+        // to a different item.
         aiPanelThumb.src = img ? img.src : '';
         aiPanelThumb.alt = name;
         aiPanelName.textContent = name;
@@ -694,12 +783,23 @@
         aiPanelEmpty.classList.add('d-none');
         aiPanelContent.classList.remove('d-none');
         aiPanelContent.classList.add('d-flex');
+        state.aiPanelCurrentId = id;
+
+        const cached = state.preGenerated.get(id);
+        if (cached) {
+            cached.promise.then(result => {
+                if (result?.ok && state.aiPanelCurrentId === id) {
+                    aiPanelThumb.src = result.blobUrl;
+                }
+            });
+        }
     }
 
     function resetAIPanel() {
         aiPanelContent.classList.add('d-none');
         aiPanelContent.classList.remove('d-flex');
         aiPanelEmpty.classList.remove('d-none');
+        state.aiPanelCurrentId = null;
     }
 
     function refreshAIPanel() {
@@ -814,38 +914,49 @@
         btnText.textContent = "GENERATING (may take 1 min)...";
         btnSpinner.classList.remove('d-none');
 
-        const wasAIRecommended = state.recommendations
-            ? state.recommendations.some(r => r.hairstyle_id === parseInt(state.selectedHairstyleId, 10))
-            : false;
-
-        const fd = new FormData();
-        fd.append("photo", state.photoFile);
-        fd.append("hairstyle_id", state.selectedHairstyleId);
-        fd.append("was_ai_recommended", wasAIRecommended ? "true" : "false");
-        if (state.observation) {
-            fd.append("observation", state.observation);
-        }
+        const idStr = String(state.selectedHairstyleId);
 
         try {
-            const res = await fetch("{{ url_for('main.generate') }}", { method: "POST", body: fd });
-            
-            if (!res.ok) {
-                const err = await res.json().catch(() => ({ error: "Generation failed" }));
-                throw new Error(err.error || "Generation failed");
+            let parsedId, blobUrl;
+            // If a pre-generation is in flight or already done for this style,
+            // reuse it instead of triggering another Gemini call.
+            const cached = state.preGenerated.get(idStr);
+            if (cached) {
+                const result = await cached.promise;
+                if (result?.ok) {
+                    // Take ownership: drop the entry so clearPreGenerated()
+                    // doesn't revoke the URL we're now displaying.
+                    state.preGenerated.delete(idStr);
+                    parsedId = result.generatedImageId;
+                    blobUrl = result.blobUrl;
+                }
             }
 
-            const idHeader = res.headers.get("X-Generated-Image-Id");
-            const parsedId = parseInt(idHeader, 10);
-            if (!Number.isFinite(parsedId)) {
-                throw new Error("Server did not return a valid image id");
+            if (parsedId === undefined) {
+                // Live call: cache miss, pre-gen failed, or non-recommended pick.
+                const fd = new FormData();
+                fd.append("photo", state.photoFile);
+                fd.append("hairstyle_id", state.selectedHairstyleId);
+                if (state.observation) fd.append("observation", state.observation);
+
+                const res = await fetch("{{ url_for('main.generate') }}", { method: "POST", body: fd });
+                if (!res.ok) {
+                    const err = await res.json().catch(() => ({ error: "Generation failed" }));
+                    throw new Error(err.error || "Generation failed");
+                }
+                const idHeader = res.headers.get("X-Generated-Image-Id");
+                parsedId = parseInt(idHeader, 10);
+                if (!Number.isFinite(parsedId)) {
+                    throw new Error("Server did not return a valid image id");
+                }
+                blobUrl = URL.createObjectURL(await res.blob());
             }
+
             state.generatedImageId = parsedId;
-            const blob = await res.blob();
-            
             if (state.generatedImageBlobUrl) {
                 URL.revokeObjectURL(state.generatedImageBlobUrl);
             }
-            state.generatedImageBlobUrl = URL.createObjectURL(blob);
+            state.generatedImageBlobUrl = blobUrl;
 
             // Populate Result Phase
             resultImg.src = state.generatedImageBlobUrl;

--- a/config.py
+++ b/config.py
@@ -14,6 +14,15 @@ class Config:
         os.environ.get("DATABASE_URL") or "sqlite:///truehair.db"
     ).replace("postgres://", "postgresql://", 1)
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    # Match the gunicorn gthread fan-out (1 worker × 8 threads in the
+    # Procfile). pool_size/max_overflow are QueuePool-only — they're rejected
+    # by StaticPool/SingletonThreadPool used for SQLite in dev and tests, so
+    # gate the QueuePool-specific args on the URI scheme.
+    SQLALCHEMY_ENGINE_OPTIONS = (
+        {"pool_size": 8, "max_overflow": 2, "pool_pre_ping": True}
+        if SQLALCHEMY_DATABASE_URI.startswith("postgresql")
+        else {}
+    )
     AUTO_CREATE_SCHEMA = True
     MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10MB
 


### PR DESCRIPTION
## Summary

- After `/api/recommend` returns 2-4 styles, kick off `/api/generate` upfront for the **top 2** recommendations in parallel. Cache the WebP blobs keyed by `hairstyle_id`. Hovering one of those two recommended cards shows a spinner over the AI panel's 64×64 thumbnail until that style's call lands; the user's preview then swaps in. Clicking Generate on a pre-gen'd style reuses the cached blob — no second Gemini call.
- Recommended cards are reordered to lead the catalog grid in recommendation order so the AI's picks are above the fold.
- Switches Procfile to `gunicorn --workers 1 --threads 8 --worker-class gthread` and bumps the SQLAlchemy connection pool to match (`pool_size=8, max_overflow=2` for Postgres only). Threaded workers let pre-gen calls run concurrently with normal traffic instead of serializing through one sync worker.

## Why upfront top-2 (and not all 4 or hover-triggered)

We tried two earlier designs in this PR and walked them back:

1. **Upfront fan-out for all 4 recs.** Vertex AI's `gemini-2.5-flash-image` reliably 429s when more than ~2 calls per project are in flight at once, and also returns text-only fallbacks under load (which the server raises as `No image returned`). In practice "only 2 of 4 thumbnails actually appear" was the typical outcome, not the exception.
2. **Lazy hover-triggered pre-gen.** Solved the up-front-wait UX problem but re-introduced the 429 hazard the moment a user hovered across multiple recommended cards in quick succession.

Capping at the top 2 recommendations gives the user instant feedback on the most-likely picks without ever exceeding the rate Vertex consistently allows. Recs 3 and 4 (when present) show the catalog placeholder in the AI panel and trigger a live `/api/generate` if the user clicks Generate on them — same path as a non-recommended pick.

## Implementation notes

- `state.preGenerated` is `Map<hairstyle_id_str, { promise, result | null }>`. `result` mirrors the resolved promise so re-hovering a settled style renders synchronously without a microtask round-trip.
- `preGenerateOne(id)` is idempotent — repeated calls for the same hairstyle return the existing entry. `preGenerateTopRecommendations` slices the rec list to `PREGEN_LIMIT = 2`.
- `showAIPanelForItem` is **read-only** against the cache: it never kicks off a generation itself, so hovering ids 3+ doesn't add fan-out pressure.
- The Generate handler awaits the cached promise; on success it takes ownership of the `blobUrl` (deletes the entry) so cleanup doesn't revoke a URL that's actively rendering on the result page.
- `state.aiPanelCurrentId` gates the post-fetch repaint so a slow result landing after the user has moved on doesn't repaint the wrong card.
- `clearPreGenerated()` runs from both `clearPhoto()` (Remove button) and `handleFileSelection()` (any new file), so a fresh photo doesn't inherit stale entries from the previous selfie.
- Pre-gen failures are silent to the user (the live-call fallback covers them), but `console.warn` is logged for observability when Vertex 429s or returns text-only.

## Caveat: dashboard metrics

Each pre-gen call writes a `GeneratedImage` row, so `activation_rate` and `retention_rate` on the Operations dashboard will inflate (every recommendation session creates up to 2 rows automatically). `ai_rec_rate` is not affected — for new users post-Track A, `was_ai_recommended` stays `None` and they're filtered out of that metric.

The metric definitions are inherited from the IRB study and are slated for redesign as part of the consumer-conversion track. A cleaner alternative (a `pregen=1` flag on `/api/generate` that skips the row write + a small endpoint to claim the row on actual selection) is a possible follow-up if the team wants to fix the metrics before the broader redesign.

## Test plan

- [x] `uv run pytest` — 106 / 106 pass.
- [x] JS syntax check (Node `--check` after stripping Jinja).
- [ ] Staging: upload photo → observation → "Find my styles" → catalog appears immediately with badges, top 2 recs at the front of the grid, no upfront spinner state on the catalog itself.
- [ ] Staging: hover one of the top 2 recommended cards → AI panel opens → 64×64 thumbnail shows catalog placeholder + spinner overlay → spinner clears and thumbnail swaps to the user's own preview.
- [ ] Staging: hover a 3rd / 4th recommended card → panel opens with catalog image, no spinner. Click Generate → live `/api/generate` runs as today.
- [ ] Staging: click Generate on a pre-gen'd style → result page renders instantly, no second Gemini call (verify in DevTools Network).
- [ ] Staging: select a different photo without clicking Remove first → confirm the previous photo's pre-gen blobs don't leak into the new recommendation set.
- [ ] DevTools Network during pre-gen: confirm exactly 2 `/api/generate` requests fire after `/api/recommend` (not 4, not 1).