### PR TITLE
feat(login): first-visit Terms modal + consumer ToS rewrite

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -439,3 +439,52 @@ a.logout-btn:hover, a.logout-btn:focus, a.logout-btn:active {
 .style-card.is-recommended:hover {
   box-shadow: 0 0 0 4px rgba(248, 205, 36, 0.35);
 }
+
+/* First-visit Terms modal on /login */
+.login-card {
+  transition: filter 0.2s ease;
+}
+
+.login-card--blurred {
+  filter: blur(4px);
+  pointer-events: none;
+  user-select: none;
+}
+
+.terms-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1080;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.terms-modal[hidden] {
+  display: none;
+}
+
+.terms-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(10, 10, 12, 0.55);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.terms-modal__dialog {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+}
+
+.terms-modal__panel {
+  padding: 1.75rem;
+}
+
+@media (min-width: 768px) {
+  .terms-modal__panel {
+    padding: 2.25rem;
+  }
+}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="container" style="max-width: 480px;">
-  <div class="bg-card rounded-4 shadow-lg border border-secondary border-opacity-25 p-4 p-md-5 text-center">
+  <div id="loginCard" class="bg-card rounded-4 shadow-lg border border-secondary border-opacity-25 p-4 p-md-5 text-center login-card">
     <img src="{{ url_for('static', filename='images/truehair-logo.png') }}"
          alt="TrueHair AI"
          height="48"
@@ -13,7 +13,8 @@
     <h1 class="fw-bold h3 mb-2 text-white">Welcome to TrueHair AI</h1>
     <p class="text-secondary mb-4">Sign in to visualize hairstyles and find a stylist.</p>
 
-    <a href="{{ url_for('google.login') }}"
+    <a id="googleLoginBtn"
+       href="{{ url_for('google.login') }}"
        class="btn btn-light fw-semibold w-100 py-3 rounded-3 d-flex align-items-center justify-content-center gap-2">
       <i class="bi bi-google" style="font-size: 1.25rem;"></i>
       <span>Sign in with Google</span>
@@ -27,6 +28,31 @@
     </p>
   </div>
 </div>
+
+<div id="termsModal" class="terms-modal" role="dialog" aria-modal="true" aria-labelledby="termsModalTitle" hidden>
+  <div class="terms-modal__backdrop"></div>
+  <div class="terms-modal__dialog" role="document">
+    <div class="terms-modal__panel bg-card rounded-4 border border-secondary border-opacity-25 shadow-lg">
+      <h2 id="termsModalTitle" class="fw-bold h4 text-white mb-3">Before you sign in</h2>
+      <p class="text-secondary mb-3" style="line-height:1.65;">
+        TrueHair AI lets you upload a photo of yourself and preview AI-generated hairstyle visualizations.
+        Your photo is processed in memory and discarded &mdash; we never store the photo or the generated
+        images. We use your Google account only to sign you in and to remember your saved sessions.
+        TrueHair AI is for personal use, on photos of yourself, and the visualizations are not a
+        substitute for professional styling advice.
+      </p>
+      <p class="text-secondary small mb-4">
+        Read the full
+        <a href="{{ url_for('main.terms') }}" target="_blank" rel="noopener" class="text-yellow text-decoration-none">Terms</a>
+        and
+        <a href="{{ url_for('main.privacy') }}" target="_blank" rel="noopener" class="text-yellow text-decoration-none">Privacy Notice</a>.
+      </p>
+      <button id="termsAcceptBtn" type="button" class="btn btn-primary fw-semibold w-100 py-3 rounded-3">
+        I agree, continue
+      </button>
+    </div>
+  </div>
+</div>
 {% endblock %}
 
 {% block navbar %}
@@ -36,4 +62,62 @@
     <span class="text-white fw-bold">TrueHair AI</span>
   </a>
 </nav>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+  (function () {
+    var STORAGE_KEY = 'terms_accepted_v1';
+    var modal = document.getElementById('termsModal');
+    var card = document.getElementById('loginCard');
+    var googleBtn = document.getElementById('googleLoginBtn');
+    var acceptBtn = document.getElementById('termsAcceptBtn');
+
+    function readAccepted() {
+      try { return localStorage.getItem(STORAGE_KEY) === '1'; }
+      catch (e) { return false; }
+    }
+
+    function writeAccepted() {
+      try { localStorage.setItem(STORAGE_KEY, '1'); }
+      catch (e) { /* private browsing — modal will reappear next visit */ }
+    }
+
+    function dismissModal() {
+      modal.hidden = true;
+      card.classList.remove('login-card--blurred');
+      googleBtn.classList.remove('login-cta-disabled');
+      googleBtn.removeAttribute('aria-disabled');
+      googleBtn.removeAttribute('tabindex');
+      acceptBtn.removeEventListener('keydown', trapTab);
+    }
+
+    function showModal() {
+      card.classList.add('login-card--blurred');
+      googleBtn.classList.add('login-cta-disabled');
+      googleBtn.setAttribute('aria-disabled', 'true');
+      googleBtn.setAttribute('tabindex', '-1');
+      modal.hidden = false;
+      acceptBtn.addEventListener('keydown', trapTab);
+      acceptBtn.focus();
+    }
+
+    // The accept button is the only focusable element inside the modal.
+    // Trap Tab/Shift-Tab on it so focus cannot escape to the (blurred) login card.
+    function trapTab(e) {
+      if (e.key === 'Tab') { e.preventDefault(); acceptBtn.focus(); }
+    }
+
+    acceptBtn.addEventListener('click', function () {
+      writeAccepted();
+      dismissModal();
+    });
+
+    if (readAccepted()) {
+      dismissModal();
+    } else {
+      showModal();
+    }
+  })();
+</script>
 {% endblock %}

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
 
-{% block title %}Terms & Educational Disclaimer - TrueHair AI{% endblock %}
+{% block title %}Terms of Service - TrueHair AI{% endblock %}
 
 {% block content %}
 <div class="container py-5">
     <div class="row justify-content-center">
         <div class="col-lg-7">
-            <h1 class="fw-bold display-5 text-white mb-2">Terms &amp; Educational Disclaimer</h1>
-            <p class="text-secondary mb-5">Last updated April 2026</p>
+            <h1 class="fw-bold display-5 text-white mb-2">Terms of Service</h1>
+            <p class="text-secondary mb-5">Last updated May 2026</p>
 
             <div class="card bg-card border border-secondary border-opacity-25 rounded-4 overflow-hidden">
 
@@ -15,18 +15,103 @@
                     <div class="d-flex align-items-center gap-3 mb-3">
                         <div class="rounded-circle d-flex align-items-center justify-content-center flex-shrink-0"
                             style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
-                            <i class="bi bi-mortarboard text-yellow"></i>
+                            <i class="bi bi-check2-circle text-yellow"></i>
                         </div>
-                        <h5 class="fw-bold text-white mb-0">Educational Prototype Disclaimer</h5>
+                        <h5 class="fw-bold text-white mb-0">1. Acceptance of these Terms</h5>
+                    </div>
+                    <p class="text-secondary mb-0" style="line-height:1.75;">
+                        By accessing or using TrueHair AI (the &ldquo;Service&rdquo;), you agree to be bound by these Terms of Service. If you do not agree, do not use the Service.
+                    </p>
+                </div>
+
+                <hr class="border-secondary border-opacity-25 m-0">
+
+                <div class="p-4 p-md-5">
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-circle d-flex align-items-center justify-content-center flex-shrink-0"
+                            style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
+                            <i class="bi bi-stars text-yellow"></i>
+                        </div>
+                        <h5 class="fw-bold text-white mb-0">2. The Service</h5>
+                    </div>
+                    <p class="text-secondary mb-0" style="line-height:1.75;">
+                        TrueHair AI lets you upload a photo of yourself and preview AI-generated visualizations of different hairstyles on that photo. The visualizations are produced by third-party generative AI models and are intended to help you explore styles and find a stylist. They are not a substitute for professional styling advice.
+                    </p>
+                </div>
+
+                <hr class="border-secondary border-opacity-25 m-0">
+
+                <div class="p-4 p-md-5">
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-circle d-flex align-items-center justify-content-center flex-shrink-0"
+                            style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
+                            <i class="bi bi-person-badge text-yellow"></i>
+                        </div>
+                        <h5 class="fw-bold text-white mb-0">3. Eligibility</h5>
+                    </div>
+                    <p class="text-secondary mb-0" style="line-height:1.75;">
+                        You must be at least 18 years old to use the Service. By using TrueHair AI, you represent that you meet this requirement.
+                    </p>
+                </div>
+
+                <hr class="border-secondary border-opacity-25 m-0">
+
+                <div class="p-4 p-md-5">
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-circle d-flex align-items-center justify-content-center flex-shrink-0"
+                            style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
+                            <i class="bi bi-google text-yellow"></i>
+                        </div>
+                        <h5 class="fw-bold text-white mb-0">4. Your account</h5>
+                    </div>
+                    <p class="text-secondary mb-0" style="line-height:1.75;">
+                        Access to TrueHair AI requires sign-in with a valid Google account. You are responsible for keeping your Google credentials secure and for any activity that occurs under your account. You may sign out at any time from the account menu.
+                    </p>
+                </div>
+
+                <hr class="border-secondary border-opacity-25 m-0">
+
+                <div class="p-4 p-md-5">
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-circle d-flex align-items-center justify-content-center flex-shrink-0"
+                            style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
+                            <i class="bi bi-shield-check text-yellow"></i>
+                        </div>
+                        <h5 class="fw-bold text-white mb-0">5. Acceptable use</h5>
                     </div>
                     <p class="text-secondary mb-3" style="line-height:1.75;">
-                        TrueHair.ai is an experimental prototype built as part of a university software engineering course project at Colby College. It is also being used as the platform for an IRB-approved research study on AI-generated hairstyle recommendations.
+                        When using TrueHair AI, you agree that you will:
+                    </p>
+                    <ul class="text-secondary mb-3" style="line-height:1.75;">
+                        <li>Only upload photos of yourself, or photos that you have an explicit right to use. <strong class="text-white">Do not upload images of other people without their consent.</strong></li>
+                        <li>Not upload nudity, sexual content, content depicting minors, or any content that is unlawful, hateful, harassing, or that infringes anyone&rsquo;s rights.</li>
+                        <li>Not attempt to interfere with, reverse-engineer, or otherwise abuse the Service or its underlying systems.</li>
+                        <li>Not use the Service to generate or distribute deceptive, misleading, or impersonating content.</li>
+                    </ul>
+                    <p class="text-secondary mb-0" style="line-height:1.75;">
+                        We may suspend or terminate access for any account that violates these rules.
+                    </p>
+                </div>
+
+                <hr class="border-secondary border-opacity-25 m-0">
+
+                <div class="p-4 p-md-5">
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-circle d-flex align-items-center justify-content-center flex-shrink-0"
+                            style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
+                            <i class="bi bi-image text-yellow"></i>
+                        </div>
+                        <h5 class="fw-bold text-white mb-0">6. Your photo and the generated visualizations</h5>
+                    </div>
+                    <p class="text-secondary mb-3" style="line-height:1.75;">
+                        You retain all rights to the photo you upload and to the AI-generated visualizations the Service produces from it. We do not claim ownership of either.
+                    </p>
+                    <p class="text-secondary mb-3" style="line-height:1.75;">
+                        Your photo is processed in memory to generate visualizations and is then discarded &mdash; we do not store the photo or the generated images on our servers. To produce a visualization, your photo is transmitted to our third-party AI provider; their handling of that transmission is described in the
+                        <a href="{{ url_for('main.privacy') }}" class="text-yellow">Privacy Notice</a>.
                     </p>
                     <p class="text-secondary mb-0" style="line-height:1.75;">
-                        If you are participating as a research subject, the
-                        <a href="{{ url_for('main.consent_page') }}" class="text-yellow">consent disclosure</a>
-                        and <a href="{{ url_for('main.privacy') }}" class="text-yellow">privacy notice</a>
-                        describe exactly what is and isn&rsquo;t recorded during a session.
+                        You grant us a limited, non-exclusive licence to process your photo solely for the purpose of generating the visualizations you request, for the duration of that request.
                     </p>
                 </div>
 
@@ -38,10 +123,13 @@
                             style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
                             <i class="bi bi-shield-exclamation text-yellow"></i>
                         </div>
-                        <h5 class="fw-bold text-white mb-0">No Liability</h5>
+                        <h5 class="fw-bold text-white mb-0">7. Disclaimers and limitation of liability</h5>
                     </div>
+                    <p class="text-secondary mb-3" style="line-height:1.75;">
+                        TrueHair AI is provided on an &ldquo;as is&rdquo; and &ldquo;as available&rdquo; basis, without warranties of any kind. AI-generated visualizations may be inaccurate, may not reflect how a hairstyle will look on you in real life, and should not be relied upon for important decisions or professional styling advice.
+                    </p>
                     <p class="text-secondary mb-0" style="line-height:1.75;">
-                        By utilizing this application, you understand and acknowledge that it is a work in progress and should not be relied upon for important decisions, critical tasks, or professional styling advice. The student developers of TrueHair.ai and Colby College assume no liability for any loss, harm, or damages resulting from the use, inability to use, or reliance on this prototype.
+                        To the fullest extent permitted by law, the operators of TrueHair AI are not liable for any loss, harm, or damages arising from your use of, inability to use, or reliance on the Service.
                     </p>
                 </div>
 
@@ -53,10 +141,56 @@
                             style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
                             <i class="bi bi-clock-history text-yellow"></i>
                         </div>
-                        <h5 class="fw-bold text-white mb-0">Service Interruptions</h5>
+                        <h5 class="fw-bold text-white mb-0">8. Service interruptions</h5>
                     </div>
                     <p class="text-secondary mb-0" style="line-height:1.75;">
-                        Because this is a testing environment, the application may experience downtime, data resets, or unexpected behavior. We do not guarantee continuous uptime or data preservation.
+                        We work to keep the Service available, but we do not guarantee continuous uptime. Features may change, be paused, or be removed at any time without notice, and access to the Service may be temporarily unavailable for maintenance or for reasons outside our control.
+                    </p>
+                </div>
+
+                <hr class="border-secondary border-opacity-25 m-0">
+
+                <div class="p-4 p-md-5">
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-circle d-flex align-items-center justify-content-center flex-shrink-0"
+                            style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
+                            <i class="bi bi-arrow-repeat text-yellow"></i>
+                        </div>
+                        <h5 class="fw-bold text-white mb-0">9. Changes to these Terms</h5>
+                    </div>
+                    <p class="text-secondary mb-0" style="line-height:1.75;">
+                        We may update these Terms from time to time. When we make material changes, we&rsquo;ll update the &ldquo;Last updated&rdquo; date above and, where appropriate, prompt you to re-accept on next sign-in. Continued use of the Service after an update means you accept the revised Terms.
+                    </p>
+                </div>
+
+                <hr class="border-secondary border-opacity-25 m-0">
+
+                <div class="p-4 p-md-5">
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-circle d-flex align-items-center justify-content-center flex-shrink-0"
+                            style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
+                            <i class="bi bi-bank text-yellow"></i>
+                        </div>
+                        <h5 class="fw-bold text-white mb-0">10. Governing law</h5>
+                    </div>
+                    <p class="text-secondary mb-0" style="line-height:1.75;">
+                        These Terms are governed by the laws of the State of Maine, United States, without regard to its conflict of laws principles. Any dispute arising from or relating to the Service shall be brought exclusively in the courts located in that jurisdiction.
+                    </p>
+                </div>
+
+                <hr class="border-secondary border-opacity-25 m-0">
+
+                <div class="p-4 p-md-5">
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-circle d-flex align-items-center justify-content-center flex-shrink-0"
+                            style="width:38px;height:38px;background-color:rgba(248,205,36,0.12);">
+                            <i class="bi bi-envelope text-yellow"></i>
+                        </div>
+                        <h5 class="fw-bold text-white mb-0">11. Contact</h5>
+                    </div>
+                    <p class="text-secondary mb-0" style="line-height:1.75;">
+                        Questions about these Terms? Reach the team at
+                        <a href="mailto:rfagya27@colby.edu" class="text-yellow">rfagya27@colby.edu</a>.
                     </p>
                 </div>
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -135,13 +135,47 @@ def test_submit_consent_is_idempotent(app, auth_client):
 
 
 def test_terms_page_public(client):
-    """Terms page is public and renders required disclaimer content."""
+    """Terms page is public and renders the consumer ToS sections."""
     response = client.get("/terms")
     assert response.status_code == 200
-    assert b"Terms &amp; Educational Disclaimer" in response.data
-    assert b"Educational Prototype Disclaimer" in response.data
-    assert b"No Liability" in response.data
-    assert b"Service Interruptions" in response.data
+    body = response.data
+    assert b"Terms of Service" in body
+    assert b"Acceptance of these Terms" in body
+    assert b"Acceptable use" in body
+    # Acceptable Use must call out third-party photo consent — moved here from
+    # the deleted IRB consent doc.
+    assert b"Do not upload images of other people without their consent" in body
+    assert b"Disclaimers and limitation of liability" in body
+    assert b"Governing law" in body
+
+
+def test_terms_page_drops_irb_framing(client):
+    """Consumer ToS rewrite must not leak IRB / research-study / course-project framing."""
+    response = client.get("/terms")
+    assert response.status_code == 200
+    text = response.data.lower()
+    assert b"irb" not in text
+    assert b"research study" not in text
+    assert b"course project" not in text
+    assert b"educational prototype" not in text
+
+
+def test_login_page_renders_terms_modal(client):
+    """/login renders the first-visit Terms modal markup; JS gates visibility on localStorage."""
+    response = client.get("/login")
+    assert response.status_code == 200
+    body = response.data
+    # Modal container, dialog role, and accept button are all present in the
+    # initial markup so the JS can show/hide it without a re-render.
+    assert b'id="termsModal"' in body
+    assert b'role="dialog"' in body
+    assert b'aria-modal="true"' in body
+    assert b'id="termsAcceptBtn"' in body
+    assert b"I agree, continue" in body
+    # The localStorage key is versioned so we can re-prompt later if Terms change.
+    assert b"terms_accepted_v1" in body
+    # Google sign-in button has the id the gating JS toggles.
+    assert b'id="googleLoginBtn"' in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Adds a non-dismissible first-visit Terms + Privacy modal to `/login` that blocks the Google sign-in button until the user accepts, and rewrites `app/templates/terms.html` from the IRB-era educational-prototype framing into a consumer Terms of Service.

## Related Issues
Closes #98
Closes #100

## Changes Made
- [x] `app/templates/login.html` — Adds a `role="dialog"` modal with a ~100-word consumer-facing summary and links to full Terms + Privacy. Inline JS gates visibility on `localStorage['terms_accepted_v1']`, blurs the login card, disables the Google button (`aria-disabled`, `tabindex=-1`, `login-cta-disabled`), focuses the accept button, and traps Tab on it. Strictly non-dismissible — no Esc, no backdrop click, no close button.
- [x] `app/static/css/styles.css` — Adds `.terms-modal__*`, `.login-card--blurred`, dim-and-blurred backdrop styles.
- [x] `app/templates/terms.html` — Full rewrite. 11 consumer sections (Acceptance, Service, 18+ Eligibility, Account, Acceptable use incl. "do not upload images of others without their consent", Photo/visualization rights, Disclaimers, Service interruptions, Changes, Governing law (Maine), Contact `rfagya27@colby.edu`). All IRB / research-study / course-project framing removed.
- [x] `tests/test_routes.py` — Rewrote `test_terms_page_public` for consumer copy; added `test_terms_page_drops_irb_framing` and `test_login_page_renders_terms_modal`.

The `_v1` suffix on the localStorage key is intentional so we can re-prompt by bumping the version if Terms change. Server-side audit trail (`User.terms_accepted_at`) is unchanged — already populated by the OAuth callback for new users.

## Testing & Verification
- `uv run pytest` — 108 tests pass.
- `uv run ruff check` — clean.
- Manual browser verification on `/login`:
  - First visit (`localStorage` empty): modal shows, login card is blurred, Google button is non-clickable, focus is on the accept button.
  - Click "I agree, continue": modal hides, card unblurs, Google button becomes interactive, `localStorage['terms_accepted_v1'] = '1'`.
  - Reload `/login`: modal stays hidden.
- Manual browser verification on `/terms`: all 11 consumer sections render; no IRB / research-study / course-project / educational-prototype strings remain; contact email links to `mailto:rfagya27@colby.edu`.

**Pre-existing gap, not addressed here:** in `app/routes/auth.py:72-87`, the pre-seeded admin claim path (`google_sub = "pending:<email>"`) falls through to the display-field-refresh branch and never sets `terms_accepted_at`. Pre-seeded admins who accept the modal will still have `NULL` on that column. Worth a follow-up issue.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Terms of Service modal appears on login for first-time users, requiring acceptance before proceeding with the application
  * Login interface updated with improved accessibility features to support the terms acceptance workflow, including focus management and keyboard navigation
  * Terms of Service page redesigned with comprehensive legal terms, service policies, user eligibility requirements, acceptable use guidelines, and governing framework

<!-- end of auto-generated comment: release notes by coderabbit.ai -->