### PR TITLE
feat(studio): custom reference upload as alternative to catalog

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -84,6 +84,9 @@ class GeneratedImage(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
     hairstyle_id = db.Column(db.Integer, db.ForeignKey("hairstyle.id"), nullable=True)
     was_ai_recommended = db.Column(db.Boolean, nullable=True)
+    used_custom_reference = db.Column(
+        db.Boolean, nullable=False, server_default=db.false(), default=False
+    )
     created_at = db.Column(
         db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -914,7 +914,15 @@ Respond with a JSON object in this exact format:
 @main_bp.route("/api/generate", methods=["POST"])
 @login_required
 def generate():
-    """Generate a new image with the selected hairstyle using Gemini."""
+    """Generate a new image using Gemini.
+
+    Two mutually exclusive paths:
+    - Catalog: caller supplies `hairstyle_id` and we transplant that named
+      style onto the user's photo.
+    - Custom reference: caller supplies a `reference_photo` multipart field
+      (a hairstyle they already like) and we transplant the hair from that
+      onto the user's photo. `hairstyle_id` is ignored on this path.
+    """
     # IRB compliance: photo bytes must not be logged or persisted.
     # Do not log request.files, request.data, or photo_bytes.
     import json
@@ -925,14 +933,18 @@ def generate():
     if not photo_file:
         return jsonify({"error": "Missing photo"}), 400
 
-    hairstyle_id = request.form.get("hairstyle_id", type=int)
+    reference_file = request.files.get("reference_photo")
+    using_reference = reference_file is not None
 
-    if not hairstyle_id:
-        return jsonify({"error": "Select a hairstyle"}), 400
+    hairstyle = None
+    if not using_reference:
+        hairstyle_id = request.form.get("hairstyle_id", type=int)
+        if not hairstyle_id:
+            return jsonify({"error": "Select a hairstyle"}), 400
 
-    hairstyle = db.session.get(Hairstyle, hairstyle_id)
-    if not hairstyle:
-        return jsonify({"error": "Invalid hairstyle"}), 400
+        hairstyle = db.session.get(Hairstyle, hairstyle_id)
+        if not hairstyle:
+            return jsonify({"error": "Invalid hairstyle"}), 400
 
     observation = (request.form.get("observation") or "").strip()
     if len(observation) > MAX_OBSERVATION_LENGTH:
@@ -942,23 +954,30 @@ def generate():
     if err:
         return err
 
+    reference_photo = None
+    if using_reference:
+        reference_photo, err = _load_validated_photo(reference_file)
+        if err:
+            return err
+
     client = get_genai_client()
     if not client:
         return jsonify({"error": "Internal server error"}), 500
 
-    exp = (
-        ExperimentSession.query.filter_by(session_id=sid)
-        .order_by(ExperimentSession.started_at.desc())
-        .first()
-    )
-
     was_ai_recommended = None
-    if exp and exp.experiment_group == "experimental":
-        rec_exists = Recommendation.query.filter_by(
-            session_id=sid,
-            hairstyle_id=hairstyle_id,
-        ).first()
-        was_ai_recommended = rec_exists is not None
+    if not using_reference:
+        exp = (
+            ExperimentSession.query.filter_by(session_id=sid)
+            .order_by(ExperimentSession.started_at.desc())
+            .first()
+        )
+
+        if exp and exp.experiment_group == "experimental":
+            rec_exists = Recommendation.query.filter_by(
+                session_id=sid,
+                hairstyle_id=hairstyle.id,
+            ).first()
+            was_ai_recommended = rec_exists is not None
 
     try:
         # Same data-not-instructions wrapping as /api/recommend.
@@ -970,16 +989,26 @@ def generate():
             if observation
             else ""
         )
-        prompt = (
-            f"Edit this person's photo to give them a '{hairstyle.name}' hairstyle. "
-            f"{hairstyle.description}. "
-            f"Keep the person's face, skin tone, and body exactly the same. "
-            f"Only change their hair.{observation_clause} Return the edited photo."
-        )
+        if using_reference:
+            prompt = (
+                "Edit this person's photo to match the hairstyle in the reference image. "
+                "The reference image shows just the hairstyle. "
+                "Keep the person's face, skin tone, and body exactly the same. "
+                f"Only change their hair.{observation_clause} Return the edited photo."
+            )
+            contents = [prompt, user_photo, reference_photo]
+        else:
+            prompt = (
+                f"Edit this person's photo to give them a '{hairstyle.name}' hairstyle. "
+                f"{hairstyle.description}. "
+                f"Keep the person's face, skin tone, and body exactly the same. "
+                f"Only change their hair.{observation_clause} Return the edited photo."
+            )
+            contents = [prompt, user_photo]
 
         response = client.models.generate_content(
             model="gemini-2.5-flash-image",
-            contents=[prompt, user_photo],
+            contents=contents,
             config=types.GenerateContentConfig(
                 response_modalities=["IMAGE"],
                 http_options=types.HttpOptions(timeout=120000),
@@ -1001,8 +1030,9 @@ def generate():
         gen_img = GeneratedImage(
             session_id=sid,
             user_id=session.get("user_id"),
-            hairstyle_id=hairstyle.id,
+            hairstyle_id=hairstyle.id if hairstyle else None,
             was_ai_recommended=was_ai_recommended,
+            used_custom_reference=using_reference,
         )
         db.session.add(gen_img)
         db.session.commit()

--- a/app/templates/result.html
+++ b/app/templates/result.html
@@ -11,7 +11,9 @@
             style="background-color: rgba(248, 205, 36, 0.1); border-color: rgba(248, 205, 36, 0.3) !important;">
             <i class="bi bi-stars"></i> TRANSFORMATION COMPLETE
         </div>
-        {% if latest_gen %}
+        {% if latest_gen and latest_gen.used_custom_reference %}
+        <h1 class="fw-bold mb-2 display-5 text-white">Your custom look is ready!</h1>
+        {% elif latest_gen and latest_gen.hairstyle %}
         <h1 class="fw-bold mb-2 display-5 text-white">The '{{ latest_gen.hairstyle.name }}' looks incredible!</h1>
         {% else %}
         <h1 class="fw-bold mb-2 display-5 text-white">Your new look is ready!</h1>
@@ -76,7 +78,7 @@
                 </a>
                 <a id="result-download"
                     href="#"
-                    {% if latest_gen %}data-download-filename="truehair_{{ latest_gen.hairstyle.name | replace(' ', '_') }}_{{ latest_gen.id }}.webp"{% endif %}
+                    {% if latest_gen %}data-download-filename="truehair_{{ (latest_gen.hairstyle.name if latest_gen.hairstyle else 'custom_reference') | replace(' ', '_') }}_{{ latest_gen.id }}.webp"{% endif %}
                     class="btn btn-dark border border-secondary border-opacity-50 rounded-3 d-flex align-items-center justify-content-center px-4 py-3 opacity-50 pointer-events-none"
                     style="background-color: #2a2a2d;" title="Download Result" aria-disabled="true">
                     <i class="bi bi-download text-white fs-5"></i>
@@ -106,8 +108,13 @@
                     <div class="mb-4">
                         <h6 class="text-yellow fw-bold mb-2">Selected Style</h6>
                         <div class="p-3 bg-dark bg-opacity-50 rounded-3 border border-secondary border-opacity-25">
+                            {% if latest_gen.used_custom_reference %}
+                            <div class="fw-bold text-white">Custom reference</div>
+                            <div class="text-secondary text-sm">Generated from a reference photo you uploaded.</div>
+                            {% elif latest_gen.hairstyle %}
                             <div class="fw-bold text-white">{{ latest_gen.hairstyle.name }}</div>
                             <div class="text-secondary text-sm">{{ latest_gen.hairstyle.description }}</div>
+                            {% endif %}
                         </div>
                     </div>
                     {% endif %}

--- a/app/templates/style_studio.html
+++ b/app/templates/style_studio.html
@@ -137,6 +137,21 @@
         </div>
 
         <div class="row g-4 mb-5" id="hairstyle-grid">
+            <!-- Bring-your-own reference tile: peer to the catalog cards. Clicking
+                 opens a file picker; uploading a valid image fires /api/generate
+                 with reference_photo and skips catalog selection. -->
+            <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2" id="reference-tile-wrapper">
+                <input type="file" id="reference-image-input" class="d-none" accept="image/png, image/jpeg, image/webp">
+                <div id="reference-tile"
+                    class="reference-tile rounded-4 position-relative overflow-hidden border border-secondary border-opacity-50 h-100 d-flex flex-column align-items-center justify-content-center text-center p-3"
+                    style="cursor: pointer; transition: all 0.2s ease; aspect-ratio: 1/1; border-style: dashed !important;"
+                    role="button" tabindex="0"
+                    aria-label="Bring your own reference photo">
+                    <i class="bi bi-cloud-upload text-yellow" style="font-size: 2rem;"></i>
+                    <div class="fw-bold text-white mt-2 text-sm">Bring your own reference</div>
+                    <div class="text-secondary mt-1" style="font-size: 0.75rem; line-height: 1.3;">Upload a photo of a hairstyle you like</div>
+                </div>
+            </div>
             {% for style in hairstyles %}
             <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 hairstyle-item" data-id="{{ style.id }}" data-category="{{ (style.category or 'UNCATEGORIZED') | upper }}" data-name="{{ style.name }}" data-description="{{ style.description or '' }}" tabindex="0">
                 <div class="style-card rounded-4 position-relative overflow-hidden border border-secondary border-opacity-25 h-100"
@@ -341,6 +356,23 @@
         transform: translateY(-4px);
         box-shadow: 0 8px 20px rgba(0,0,0,0.4);
     }
+
+    .reference-tile {
+        background-color: rgba(248, 205, 36, 0.04);
+    }
+
+    .reference-tile:hover,
+    .reference-tile:focus-visible {
+        transform: translateY(-4px);
+        box-shadow: 0 8px 20px rgba(0,0,0,0.4);
+        border-color: var(--th-yellow) !important;
+        background-color: rgba(248, 205, 36, 0.08);
+    }
+
+    .reference-tile.is-busy {
+        opacity: 0.6;
+        cursor: progress;
+    }
 </style>
 
 <script type="module">
@@ -352,6 +384,7 @@
         selectedHairstyleId: null,
         selectedHairstyleName: null,
         selectedHairstyleDesc: null,
+        referenceFile: null,            // user-uploaded reference image (catalog OR reference, not both)
         aiPanelClickedId: null,
         aiPanelCurrentId: null,         // currently displayed item id (hover or click)
         generatedImageId: null,         // set after /api/generate
@@ -406,6 +439,9 @@
     const categoryFilterButtons = document.querySelectorAll('.category-filter');
     const hairstyleItems = document.querySelectorAll('.hairstyle-item');
     
+    const referenceTile = document.getElementById('reference-tile');
+    const referenceImageInput = document.getElementById('reference-image-input');
+
     const tryAnotherBtn = document.getElementById('try-another-btn');
     const resultImg = document.getElementById('result-img');
     const resultImgModal = document.getElementById('result-image-modal');
@@ -946,36 +982,51 @@
     }
 
     // --- Phase 3 → 4 (Generate) ---
-    generateBtn.addEventListener("click", async () => {
-        if (!state.photoFile || !state.selectedHairstyleId) return;
+    async function runGenerate({ useReference }) {
+        if (!state.photoFile) return;
+        if (useReference) {
+            if (!state.referenceFile) return;
+        } else if (!state.selectedHairstyleId) {
+            return;
+        }
 
         generateBtn.disabled = true;
         btnText.textContent = "GENERATING (may take 1 min)...";
         btnSpinner.classList.remove('d-none');
-
-        const idStr = String(state.selectedHairstyleId);
+        if (useReference) referenceTile.classList.add('is-busy');
 
         try {
             let parsedId, blobUrl;
-            // If a pre-generation is in flight or already done for this style,
-            // reuse it instead of triggering another Gemini call.
-            const cached = state.preGenerated.get(idStr);
-            if (cached) {
-                const result = await cached.promise;
-                if (result?.ok) {
-                    // Take ownership: drop the entry so clearPreGenerated()
-                    // doesn't revoke the URL we're now displaying.
-                    state.preGenerated.delete(idStr);
-                    parsedId = result.generatedImageId;
-                    blobUrl = result.blobUrl;
+
+            if (!useReference) {
+                // Catalog path: if a pre-generation is in flight or already done
+                // for this style, reuse it instead of triggering another Gemini
+                // call. Reference uploads bypass the cache — there's no pre-gen
+                // for an image the user just picked.
+                const idStr = String(state.selectedHairstyleId);
+                const cached = state.preGenerated.get(idStr);
+                if (cached) {
+                    const result = await cached.promise;
+                    if (result?.ok) {
+                        // Take ownership: drop the entry so clearPreGenerated()
+                        // doesn't revoke the URL we're now displaying.
+                        state.preGenerated.delete(idStr);
+                        parsedId = result.generatedImageId;
+                        blobUrl = result.blobUrl;
+                    }
                 }
             }
 
             if (parsedId === undefined) {
-                // Live call: cache miss, pre-gen failed, or non-recommended pick.
+                // Live call: cache miss, pre-gen failed, non-recommended pick,
+                // or reference path.
                 const fd = new FormData();
                 fd.append("photo", state.photoFile);
-                fd.append("hairstyle_id", state.selectedHairstyleId);
+                if (useReference) {
+                    fd.append("reference_photo", state.referenceFile);
+                } else {
+                    fd.append("hairstyle_id", state.selectedHairstyleId);
+                }
                 if (state.observation) fd.append("observation", state.observation);
 
                 const res = await fetch("{{ url_for('main.generate') }}", { method: "POST", body: fd });
@@ -1000,16 +1051,25 @@
             // Populate Result Phase
             resultImg.src = state.generatedImageBlobUrl;
             resultImgModal.src = state.generatedImageBlobUrl;
-            
+
+            const downloadLabel = useReference
+                ? "custom_reference"
+                : state.selectedHairstyleName.replace(/\s+/g, '_');
             resultDownload.href = state.generatedImageBlobUrl;
-            resultDownload.setAttribute('download', `truehair_${state.selectedHairstyleName.replace(/\s+/g, '_')}_${state.generatedImageId}.webp`);
-            
-            resultTitle.textContent = `The '${state.selectedHairstyleName}' looks incredible!`;
-            resultStyleName.textContent = state.selectedHairstyleName;
-            resultStyleDesc.textContent = state.selectedHairstyleDesc;
-            
+            resultDownload.setAttribute('download', `truehair_${downloadLabel}_${state.generatedImageId}.webp`);
+
+            if (useReference) {
+                resultTitle.textContent = "Your custom look is ready!";
+                resultStyleName.textContent = "Custom reference";
+                resultStyleDesc.textContent = "Generated from a reference photo you uploaded.";
+            } else {
+                resultTitle.textContent = `The '${state.selectedHairstyleName}' looks incredible!`;
+                resultStyleName.textContent = state.selectedHairstyleName;
+                resultStyleDesc.textContent = state.selectedHairstyleDesc;
+            }
+
             initRatingWidget(state.generatedImageId);
-            
+
             showPhase("result");
         } catch (err) {
             console.error(err);
@@ -1018,7 +1078,45 @@
             generateBtn.disabled = false;
             btnText.textContent = "GENERATE MY NEW LOOK";
             btnSpinner.classList.add('d-none');
+            referenceTile.classList.remove('is-busy');
+            checkEnableGenerate();
         }
+    }
+
+    generateBtn.addEventListener("click", () => runGenerate({ useReference: false }));
+
+    // --- Reference tile (bring-your-own hairstyle) ---
+    const ALLOWED_REFERENCE_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
+
+    function openReferencePicker() {
+        if (referenceTile.classList.contains('is-busy')) return;
+        referenceImageInput.click();
+    }
+
+    referenceTile.addEventListener('click', openReferencePicker);
+    referenceTile.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            openReferencePicker();
+        }
+    });
+
+    referenceImageInput.addEventListener('change', function () {
+        if (!this.files || !this.files[0]) return;
+        const file = this.files[0];
+        // Reset the input value so re-picking the same file still fires `change`.
+        this.value = '';
+
+        if (!ALLOWED_REFERENCE_TYPES.includes(file.type)) {
+            showFlashMessage('Please pick a PNG, JPG, or WebP image.');
+            return;
+        }
+
+        // Catalog OR reference, not both — clear any catalog selection so we
+        // don't silently override the user's earlier pick.
+        clearCatalogSelection();
+        state.referenceFile = file;
+        runGenerate({ useReference: true });
     });
 
     // --- Section 4: Rating Widget ---
@@ -1073,7 +1171,8 @@
             URL.revokeObjectURL(state.generatedImageBlobUrl);
             state.generatedImageBlobUrl = null;
         }
-        // Keep photoFile, keep recommendations, clear selection
+        // Keep photoFile, keep recommendations, clear selection + any reference.
+        state.referenceFile = null;
         clearCatalogSelection();
         showPhase("catalog");
         window.scrollTo({ top: 0, behavior: "smooth" });

--- a/migrations/versions/c2a3b4d5e6f7_add_used_custom_reference_to_generated_image.py
+++ b/migrations/versions/c2a3b4d5e6f7_add_used_custom_reference_to_generated_image.py
@@ -1,0 +1,37 @@
+"""add used_custom_reference column to generated_image
+
+Revision ID: c2a3b4d5e6f7
+Revises: f1a2b3c4d5e6
+Create Date: 2026-05-08 16:00:00.000000
+
+Tracks whether a GeneratedImage row was produced from a user-uploaded
+reference image instead of a catalog hairstyle. NOT NULL with a False
+default so existing rows backfill cleanly. When True, hairstyle_id is
+NULL — the two paths are mutually exclusive (catalog OR reference, not
+both, per Sprint 6 planning).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c2a3b4d5e6f7"
+down_revision = "f1a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("generated_image") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "used_custom_reference",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("generated_image") as batch_op:
+        batch_op.drop_column("used_custom_reference")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -831,6 +831,107 @@ def test_api_generate_sets_was_ai_recommended_false_when_style_not_recommended(
 
 
 # ---------------------------------------------------------------------------
+# Custom reference upload path (issue #97)
+# ---------------------------------------------------------------------------
+
+
+@patch("app.routes.main.get_genai_client")
+def test_api_generate_with_reference_photo_records_custom_reference(
+    mock_get_client, app, auth_client, hairstyle
+):
+    """A reference_photo upload generates an image with hairstyle_id NULL
+    and used_custom_reference=True."""
+    mock_get_client.return_value = _mock_generate_client()
+
+    response = auth_client.post(
+        "/api/generate",
+        data={
+            "photo": (make_test_image(), "selfie.jpg"),
+            "reference_photo": (make_test_image(), "inspiration.jpg"),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    gen_id = int(response.headers["X-Generated-Image-Id"])
+    with app.app_context():
+        gen_img = db.session.get(GeneratedImage, gen_id)
+        assert gen_img.hairstyle_id is None
+        assert gen_img.used_custom_reference is True
+        assert gen_img.was_ai_recommended is None
+
+
+@patch("app.routes.main.get_genai_client")
+def test_api_generate_with_reference_photo_ignores_hairstyle_id(
+    mock_get_client, app, auth_client, hairstyle
+):
+    """When reference_photo is present, hairstyle_id is ignored — catalog OR reference,
+    not both. The row stores hairstyle_id=NULL even if the form submitted one."""
+    mock_get_client.return_value = _mock_generate_client()
+
+    response = auth_client.post(
+        "/api/generate",
+        data={
+            "photo": (make_test_image(), "selfie.jpg"),
+            "reference_photo": (make_test_image(), "inspiration.jpg"),
+            "hairstyle_id": str(hairstyle.id),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    gen_id = int(response.headers["X-Generated-Image-Id"])
+    with app.app_context():
+        gen_img = db.session.get(GeneratedImage, gen_id)
+        assert gen_img.hairstyle_id is None
+        assert gen_img.used_custom_reference is True
+
+
+@patch("app.routes.main.get_genai_client")
+def test_api_generate_with_reference_photo_passes_both_images_to_gemini(
+    mock_get_client, app, auth_client
+):
+    """The Gemini call sees the user's selfie and the reference image, plus
+    a prompt that targets the reference's hair (not a catalog name)."""
+    mock_get_client.return_value = _mock_generate_client()
+
+    response = auth_client.post(
+        "/api/generate",
+        data={
+            "photo": (make_test_image(), "selfie.jpg"),
+            "reference_photo": (make_test_image(), "inspiration.jpg"),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    call_kwargs = mock_get_client.return_value.models.generate_content.call_args.kwargs
+    contents = call_kwargs["contents"]
+    # prompt + selfie + reference
+    assert len(contents) == 3
+    prompt = contents[0]
+    assert "reference image" in prompt.lower()
+
+
+def test_api_generate_rejects_corrupted_reference_photo(auth_client):
+    """A corrupted reference_photo is rejected before Gemini is called."""
+    response = auth_client.post(
+        "/api/generate",
+        data={
+            "photo": (make_test_image(), "selfie.jpg"),
+            "reference_photo": (
+                io.BytesIO(b"not-an-image"),
+                "ref.jpg",
+                "image/jpeg",
+            ),
+        },
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert b"Invalid or corrupted" in response.data
+
+
+# ---------------------------------------------------------------------------
 # Upload validation (size / MIME / corruption) for /api/generate and /api/recommend
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Adds a "Bring your own reference" tile to the Style Studio catalog grid as an alternative to picking from the predefined catalog. Clicking it opens a file picker; uploading a valid image fires `/api/generate` with a `reference_photo` multipart field and skips catalog selection. The two paths are mutually exclusive (catalog **OR** reference, not both, per Sprint 6 planning). The 2-stage pipeline's observation still runs in the upload phase and feeds the generation regardless of which path the user takes.

## Related Issues

Closes #97

## Changes Made

- [x] Add `GeneratedImage.used_custom_reference` boolean column (`NOT NULL`, default `False`) plus matching Alembic migration `c2a3b4d5e6f7`
- [x] Extend `/api/generate` to accept an optional `reference_photo`; when present, `hairstyle_id` is ignored, the prompt targets the reference's hair, and both the selfie and reference are sent to Gemini
- [x] Add the "Bring your own reference" tile (dashed border, upload icon) as a peer to catalog cards in `style_studio.html`; refactor the generate handler so catalog and reference share `runGenerate({ useReference })`
- [x] Update `/result/<id>` to branch on `used_custom_reference` so reference-path generations render as "Custom reference" instead of crashing on the missing hairstyle join

## Testing & Verification

Server-side coverage (4 new tests added):
- reference upload records `hairstyle_id IS NULL` and `used_custom_reference=True`
- `hairstyle_id` form field is ignored when `reference_photo` is present
- Gemini receives prompt + selfie + reference (3 contents) and the prompt mentions "reference image"
- Corrupted reference image is rejected before Gemini is called

Full suite: **112 passing** (108 existing + 4 new).

Other checks:
- Migration roundtrip (`db upgrade` → `db downgrade` → `db upgrade`) clean on SQLite
- `ruff check` and `ruff format --check` clean
- Both `/result/<id>` paths render 200 via the test client: "Your custom look is ready!" + "Custom reference" for the reference path, original "The '<name>' looks incredible!" for catalog

Not verified end-to-end in a browser — port 8000 was held by an existing Flask process locally, so rendering was checked programmatically through the test client rather than against live Gemini.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings