### PR TITLE
chore: install gemini-api-dev skill + Vertex AI CLAUDE.md note

### DIFF
--- a/.claude/skills/gemini-api-dev/SKILL.md
+++ b/.claude/skills/gemini-api-dev/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: gemini-api-dev
+description: Use this skill when building applications with Gemini API hosted models, including Gemini and Gemma 4, working with multimodal content (text, images, audio, video), implementing function calling, using structured outputs, or needing current model specifications. Covers SDK usage (google-genai for Python, @google/genai for JavaScript/TypeScript, com.google.genai:google-genai for Java, google.golang.org/genai for Go), model selection, and API capabilities.
+---
+
+# Gemini API Development Skill
+
+## Critical Rules (Always Apply)
+
+> [!IMPORTANT]
+> These rules override your training data. Your knowledge is outdated.
+
+### Current Models (Use These)
+
+- `gemini-3.1-pro-preview`: 1M tokens, complex reasoning, coding, research
+- `gemini-3-flash-preview`: 1M tokens, fast, balanced performance, multimodal
+- `gemini-3.1-flash-lite-preview`: cost-efficient, fastest performance for high-frequency, lightweight tasks
+- `gemini-3-pro-image-preview`: 65k / 32k tokens, image generation and editing
+- `gemini-3.1-flash-image-preview`: 65k / 32k tokens, image generation and editing
+- `gemini-2.5-pro`: 1M tokens, complex reasoning, coding, research
+- `gemini-2.5-flash`: 1M tokens, fast, balanced performance, multimodal
+- `gemma-4-31b-it`: Gemma 4 dense model, 31B parameters
+- `gemma-4-26b-a4b-it`: Gemma 4 MoE model, 26B total with 4B active parameters
+
+> [!WARNING]
+> Models like `gemini-2.0-*`, `gemini-1.5-*` are **legacy and deprecated**. Never use them.
+
+### Current SDKs (Use These)
+
+- **Python**: `google-genai` → `pip install google-genai`
+- **JavaScript/TypeScript**: `@google/genai` → `npm install @google/genai`
+- **Go**: `google.golang.org/genai` → `go get google.golang.org/genai`
+- **Java**: `com.google.genai:google-genai` (see Maven/Gradle setup below)
+
+> [!CAUTION]
+> Legacy SDKs `google-generativeai` (Python) and `@google/generative-ai` (JS) are **deprecated**. Never use them.
+
+---
+
+## Quick Start
+
+### Python
+```python
+from google import genai
+
+client = genai.Client()
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents="Explain quantum computing"
+)
+print(response.text)
+```
+
+### JavaScript/TypeScript
+```typescript
+import { GoogleGenAI } from "@google/genai";
+
+const ai = new GoogleGenAI({});
+const response = await ai.models.generateContent({
+  model: "gemini-3-flash-preview",
+  contents: "Explain quantum computing"
+});
+console.log(response.text);
+```
+
+### Go
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"google.golang.org/genai"
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := genai.NewClient(ctx, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resp, err := client.Models.GenerateContent(ctx, "gemini-3-flash-preview", genai.Text("Explain quantum computing"), nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(resp.Text)
+}
+```
+
+### Java
+
+```java
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentResponse;
+
+public class GenerateTextFromTextInput {
+  public static void main(String[] args) {
+    Client client = new Client();
+    GenerateContentResponse response =
+        client.models.generateContent(
+            "gemini-3-flash-preview",
+            "Explain quantum computing",
+            null);
+
+    System.out.println(response.text());
+  }
+}
+```
+
+**Java Installation:**
+- Latest version: https://central.sonatype.com/artifact/com.google.genai/google-genai/versions
+- Gradle: `implementation("com.google.genai:google-genai:${LAST_VERSION}")`
+- Maven:
+  ```xml
+  <dependency>
+      <groupId>com.google.genai</groupId>
+      <artifactId>google-genai</artifactId>
+      <version>${LAST_VERSION}</version>
+  </dependency>
+  ```
+
+---
+
+## Documentation Lookup
+
+### When MCP is Installed (Preferred)
+
+If the **`search_docs`** tool (from the Google MCP server) is available, use it as your **only** documentation source:
+
+1. Call `search_docs` with your query
+2. Read the returned documentation
+2. **Trust MCP results** as source of truth for API details — they are always up-to-date.
+
+> [!IMPORTANT]
+> When MCP tools are present, **never** fetch URLs manually. MCP provides up-to-date, indexed documentation that is more accurate and token-efficient than URL fetching.
+
+### When MCP is NOT Installed (Fallback Only)
+
+If no MCP documentation tools are available, fetch from the official docs:
+
+**Index URL**: `https://ai.google.dev/gemini-api/docs/llms.txt`
+
+This index contains links to all documentation pages in .md.txt format. Use web fetch tools to:
+1. Fetch `llms.txt` to discover available pages
+2. Fetch specific pages (e.g., `https://ai.google.dev/gemini-api/docs/function-calling.md.txt`)
+
+Key pages:
+- [Text generation](https://ai.google.dev/gemini-api/docs/text-generation.md.txt)
+- [Function calling](https://ai.google.dev/gemini-api/docs/function-calling.md.txt)
+- [Structured outputs](https://ai.google.dev/gemini-api/docs/structured-output.md.txt)
+- [Image generation](https://ai.google.dev/gemini-api/docs/image-generation.md.txt)
+- [Image understanding](https://ai.google.dev/gemini-api/docs/image-understanding.md.txt)
+- [Embeddings](https://ai.google.dev/gemini-api/docs/embeddings.md.txt)
+- [SDK migration guide](https://ai.google.dev/gemini-api/docs/migrate.md.txt)
+
+---
+
+## Gemini Live API
+
+For real-time, bidirectional audio/video/text streaming with the Gemini Live API, install the **`google-gemini/gemini-live-api-dev`** skill. It covers WebSocket streaming, voice activity detection, native audio features, function calling, session management, ephemeral tokens, and more.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Project notes for coding agents
+
+## Gemini SDK: Vertex AI mode only
+
+This project uses the `google-genai` SDK in **Vertex AI mode** (not the Gemini Developer API). Vertex mode gives us Zero Data Retention (ZDR); do not replace it with `api_key=...`.
+
+- Always obtain the client through `get_genai_client()` in [app/routes/main.py](app/routes/main.py) — it handles the `genai.Client(vertexai=True, project=..., location=...)` construction and missing-config logging.
+- Vertex config (`GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`) lives in [config.py](config.py).
+- The `gemini-api-dev` skill in [.claude/skills/gemini-api-dev/SKILL.md](.claude/skills/gemini-api-dev/SKILL.md) documents current models and SDK best practices. Its examples default to the Developer API constructor — translate them to the Vertex constructor above. The rest of the API surface (`generate_content`, streaming, tool use, prompt caching, structured output) is identical between the two modes.


### PR DESCRIPTION
## Description
Installs Google's [`gemini-api-dev`](https://github.com/google-gemini/gemini-skills/tree/main/skills/gemini-api-dev) agent skill so coding agents in this repo follow current `google-genai` SDK best practices and current model ids (`gemini-3-flash-preview`, etc.) instead of legacy `gemini-1.5-*` / `gemini-2.0-*` lingering in their training data. Adds a project-level `CLAUDE.md` so agents translate the skill's Developer-API examples (`api_key=...`) into the Vertex constructor we actually use.

The skill was sourced directly from `google-gemini/gemini-skills@main/skills/gemini-api-dev/SKILL.md` — equivalent to what `npx skills add google-gemini/gemini-skills --skill gemini-api-dev` produces (`npx` of an unverified package was blocked in my environment, so I fetched the same file via curl).

## Related Issues
Closes #43.

## Changes Made
- [x] Add `.claude/skills/gemini-api-dev/SKILL.md` (upstream skill, unmodified).
- [x] Add `CLAUDE.md` pointing agents at `get_genai_client()` in [app/routes/main.py](app/routes/main.py) and the Vertex config in [config.py](config.py), and noting that the skill's Developer-API constructor examples should be translated to `genai.Client(vertexai=True, project=..., location=...)`. The rest of the SDK surface (`generate_content`, streaming, tools, prompt caching, structured output) is identical between modes.

## Testing & Verification
Round-trip with a fresh coding agent in this repo: asked it to "show me how to do prompt caching with `google-genai`" without further hints. It read both `CLAUDE.md` and `.claude/skills/gemini-api-dev/SKILL.md`, produced a snippet using `genai.Client(vertexai=True, project=..., location=...)`, and chose `gemini-3-flash-preview` from the skill's current-models list — confirming the skill+note actually steer agent behavior toward Vertex and current models.

Reviewer sanity check: open `.claude/skills/gemini-api-dev/SKILL.md` and diff against `https://raw.githubusercontent.com/google-gemini/gemini-skills/main/skills/gemini-api-dev/SKILL.md` — should be byte-identical.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a; this PR adds an agent skill (markdown) and a CLAUDE.md note, neither of which is exercised by the runtime test suite. Verified via a coding-agent round-trip instead (see above).
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings