### PR TITLE
Implement gallery feature using per-user encrypted IndexedDB

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -35,7 +35,7 @@ from app.models import (
     Visit,
     db,
 )
-from app.services.auth import admin_required, login_required
+from app.services.auth import admin_required, current_user, login_required
 from app.services.session_identity import (
     consent_required,
     get_session_id,
@@ -190,6 +190,34 @@ def style_studio():
     return render_template(
         "style_studio.html", hairstyles=hairstyles, categories=categories
     )
+
+
+@main_bp.route("/gallery")
+@login_required
+def gallery():
+    """Render the user's encrypted-on-device visualization gallery.
+
+    The page is a thin shell — the visualizations themselves live encrypted
+    in IndexedDB on the user's machine and are decrypted by gallery.js using
+    a key derived from `(user_id, storage_salt)`. Server-side photo storage
+    is still off the table per product policy.
+    """
+    log_visit("Gallery")
+    return render_template("gallery.html")
+
+
+@main_bp.route("/api/me/storage-key")
+@login_required
+def storage_key():
+    """Return the data needed to derive the per-user IndexedDB encryption key.
+
+    The salt is generated once at User creation and persists across logins,
+    so visualizations encrypted on a previous session decrypt on later ones.
+    Combining it with `user_id` ensures a different account on the same
+    browser cannot decrypt the previous user's blobs.
+    """
+    user = current_user()
+    return jsonify({"user_id": user.id, "salt": user.storage_salt})
 
 
 @main_bp.route("/stylists")

--- a/app/static/js/gallery.js
+++ b/app/static/js/gallery.js
@@ -1,0 +1,153 @@
+// Per-user encrypted gallery: AES-GCM blobs in IndexedDB.
+//
+// Design constraints (issue #106):
+// - Server never stores generated images (IRB-era rule preserved as product
+//   policy). Only the client holds the WebP bytes.
+// - Encryption key is derived from `${user_id}:${storage_salt}` via PBKDF2 +
+//   AES-GCM, so a different account on the same browser cannot decrypt the
+//   previous user's blobs.
+// - Records are keyed by `[user_id, generated_image_id]` and indexed by
+//   `user_id`, so loadAllForCurrentUser() never even surfaces another user's
+//   ciphertext (the encryption layer is the second line of defense).
+//
+// Public surface:
+//   - persistGeneratedImage(blob, { id, hairstyle_name, created_at? })
+//   - loadAllForCurrentUser() -> [{ id, hairstyle_name, created_at, blob }]
+
+const DB_NAME = "truehair_gallery";
+const DB_VERSION = 1;
+const STORE = "visualizations";
+const PBKDF2_ITERATIONS = 100_000;
+
+let cachedKey = null;
+
+async function getKey() {
+    if (cachedKey) return cachedKey;
+    const res = await fetch("/api/me/storage-key", { credentials: "same-origin" });
+    if (!res.ok) {
+        throw new Error(`storage-key fetch failed: ${res.status}`);
+    }
+    const { user_id, salt } = await res.json();
+    const enc = new TextEncoder();
+    const seed = enc.encode(`${user_id}:${salt}`);
+    const baseKey = await crypto.subtle.importKey(
+        "raw",
+        seed,
+        "PBKDF2",
+        false,
+        ["deriveKey"],
+    );
+    const key = await crypto.subtle.deriveKey(
+        {
+            name: "PBKDF2",
+            salt: enc.encode(salt),
+            iterations: PBKDF2_ITERATIONS,
+            hash: "SHA-256",
+        },
+        baseKey,
+        { name: "AES-GCM", length: 256 },
+        false,
+        ["encrypt", "decrypt"],
+    );
+    cachedKey = { key, user_id };
+    return cachedKey;
+}
+
+function openDB() {
+    return new Promise((resolve, reject) => {
+        const req = indexedDB.open(DB_NAME, DB_VERSION);
+        req.onupgradeneeded = (event) => {
+            const db = event.target.result;
+            if (!db.objectStoreNames.contains(STORE)) {
+                const store = db.createObjectStore(STORE, {
+                    keyPath: ["user_id", "id"],
+                });
+                store.createIndex("by_user", "user_id");
+            }
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+    });
+}
+
+async function encryptBlob(key, blob) {
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const buf = await blob.arrayBuffer();
+    const ciphertext = await crypto.subtle.encrypt(
+        { name: "AES-GCM", iv },
+        key,
+        buf,
+    );
+    return { iv, ciphertext };
+}
+
+async function decryptBlob(key, { iv, ciphertext }) {
+    const buf = await crypto.subtle.decrypt(
+        { name: "AES-GCM", iv },
+        key,
+        ciphertext,
+    );
+    return new Blob([buf], { type: "image/webp" });
+}
+
+export async function persistGeneratedImage(blob, metadata) {
+    if (!blob) throw new Error("persistGeneratedImage: missing blob");
+    if (metadata == null || metadata.id == null) {
+        throw new Error("persistGeneratedImage: missing metadata.id");
+    }
+
+    const { key, user_id } = await getKey();
+    const { iv, ciphertext } = await encryptBlob(key, blob);
+    const db = await openDB();
+
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE, "readwrite");
+        tx.objectStore(STORE).put({
+            id: metadata.id,
+            user_id,
+            hairstyle_name: metadata.hairstyle_name || "",
+            created_at: metadata.created_at || new Date().toISOString(),
+            iv,
+            ciphertext,
+        });
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        tx.onabort = () => reject(tx.error);
+    });
+}
+
+export async function loadAllForCurrentUser() {
+    const { key, user_id } = await getKey();
+    const db = await openDB();
+
+    const records = await new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE, "readonly");
+        const req = tx.objectStore(STORE).index("by_user").getAll(user_id);
+        req.onsuccess = () => resolve(req.result || []);
+        req.onerror = () => reject(req.error);
+    });
+
+    const decrypted = [];
+    for (const rec of records) {
+        try {
+            const blob = await decryptBlob(key, {
+                iv: rec.iv,
+                ciphertext: rec.ciphertext,
+            });
+            decrypted.push({
+                id: rec.id,
+                hairstyle_name: rec.hairstyle_name,
+                created_at: rec.created_at,
+                blob,
+            });
+        } catch (e) {
+            // Almost always means a different user's record (key mismatch). The
+            // user_id index above already filters those out, so this branch is
+            // a true integrity failure — record id but not the bytes.
+            console.warn(`gallery: failed to decrypt record id=${rec.id}`, e);
+        }
+    }
+
+    decrypted.sort((a, b) => (b.created_at || "").localeCompare(a.created_at || ""));
+    return decrypted;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -45,6 +45,8 @@
                 <a href="{{ url_for('main.style_studio') }}"
                     class="{% if request.endpoint == 'main.style_studio' %}text-yellow{% else %}text-white{% endif %} text-decoration-none fw-semibold text-sm nav-link-hover">Style
                     Studio</a>
+                <a href="{{ url_for('main.gallery') }}"
+                    class="{% if request.endpoint == 'main.gallery' %}text-yellow{% else %}text-white{% endif %} text-decoration-none fw-semibold text-sm nav-link-hover">Gallery</a>
                 <a href="{{ url_for('main.stylists') }}"
                     class="{% if request.endpoint == 'main.stylists' %}text-yellow{% else %}text-white{% endif %} text-decoration-none fw-semibold text-sm nav-link-hover">Stylist
                     Directory</a>

--- a/app/templates/gallery.html
+++ b/app/templates/gallery.html
@@ -1,0 +1,159 @@
+{% extends 'base.html' %}
+
+{% block title %}Gallery - TrueHair AI{% endblock %}
+
+{% block content %}
+<div class="container py-5" style="max-width: 1200px;">
+
+    <!-- Header -->
+    <div class="mb-4 col-lg-8">
+        <h1 class="fw-bold mb-2 display-5 text-white">Your Gallery</h1>
+        <p class="text-secondary fs-5 pe-xl-5">Every visualization you've generated, encrypted and stored only on this
+            device.</p>
+    </div>
+
+    <!-- One-time first-visit notice. JS toggles d-none after the user dismisses. -->
+    <div id="gallery-first-visit-notice"
+        class="alert d-none align-items-start gap-3 border border-secondary border-opacity-25 rounded-4 mb-4 p-4"
+        style="background-color: rgba(248, 205, 36, 0.08);" role="alert">
+        <i class="bi bi-shield-lock text-yellow fs-4 mt-1"></i>
+        <div class="flex-grow-1 text-secondary">
+            These visualizations live only on this device. Clearing your browser's site data will permanently delete
+            them. Save anything you want to keep using the Download button.
+        </div>
+        <button type="button" id="gallery-notice-dismiss"
+            class="btn-close btn-close-white" aria-label="Dismiss"></button>
+    </div>
+
+    <!-- Loading state -->
+    <div id="gallery-loading" class="text-center py-5">
+        <div class="spinner-border text-yellow" role="status">
+            <span class="visually-hidden">Loading…</span>
+        </div>
+        <div class="text-secondary mt-3">Decrypting your visualizations…</div>
+    </div>
+
+    <!-- Empty state -->
+    <div id="gallery-empty" class="d-none text-center py-5">
+        <i class="bi bi-images text-secondary" style="font-size: 3rem;"></i>
+        <h4 class="text-white fw-bold mt-3 mb-2">No visualizations yet</h4>
+        <p class="text-secondary mb-4">Generate a look in the Style Studio and it'll appear here.</p>
+        <a href="{{ url_for('main.style_studio') }}" class="btn btn-primary fw-bold px-4 py-2 text-dark">
+            <i class="bi bi-magic"></i> Open Style Studio
+        </a>
+    </div>
+
+    <!-- Error state -->
+    <div id="gallery-error" class="d-none alert alert-danger border-0" role="alert">
+        <i class="bi bi-exclamation-triangle"></i>
+        <span id="gallery-error-message">We couldn't load your gallery.</span>
+    </div>
+
+    <!-- Grid -->
+    <div id="gallery-grid" class="row g-4 d-none"></div>
+
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script type="module">
+    import { loadAllForCurrentUser } from "{{ url_for('static', filename='js/gallery.js') }}";
+
+    const TOOLTIP_KEY = "gallery_tooltip_seen_v1";
+
+    const loadingEl = document.getElementById("gallery-loading");
+    const emptyEl = document.getElementById("gallery-empty");
+    const errorEl = document.getElementById("gallery-error");
+    const errorMsg = document.getElementById("gallery-error-message");
+    const gridEl = document.getElementById("gallery-grid");
+    const noticeEl = document.getElementById("gallery-first-visit-notice");
+    const dismissBtn = document.getElementById("gallery-notice-dismiss");
+
+    // First-visit tooltip — show until the user dismisses it once.
+    if (!localStorage.getItem(TOOLTIP_KEY)) {
+        noticeEl.classList.remove("d-none");
+        noticeEl.classList.add("d-flex");
+    }
+    dismissBtn.addEventListener("click", () => {
+        noticeEl.classList.add("d-none");
+        noticeEl.classList.remove("d-flex");
+        localStorage.setItem(TOOLTIP_KEY, "1");
+    });
+
+    function escapeHtml(s) {
+        return String(s).replace(/[&<>"']/g, (c) => ({
+            "&": "&amp;",
+            "<": "&lt;",
+            ">": "&gt;",
+            '"': "&quot;",
+            "'": "&#39;",
+        }[c]));
+    }
+
+    function formatDate(iso) {
+        if (!iso) return "";
+        const d = new Date(iso);
+        if (Number.isNaN(d.getTime())) return "";
+        return d.toLocaleString(undefined, {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+        });
+    }
+
+    function render(items) {
+        loadingEl.classList.add("d-none");
+
+        if (!items.length) {
+            emptyEl.classList.remove("d-none");
+            return;
+        }
+
+        gridEl.classList.remove("d-none");
+
+        const frag = document.createDocumentFragment();
+        for (const item of items) {
+            const url = URL.createObjectURL(item.blob);
+            const safeName = item.hairstyle_name || "Custom reference";
+            const filenameStem = safeName.replace(/\s+/g, "_") || "visualization";
+
+            const col = document.createElement("div");
+            col.className = "col-12 col-sm-6 col-md-4 col-lg-3";
+            col.innerHTML = `
+                <div class="bg-card rounded-4 border border-secondary border-opacity-25 overflow-hidden h-100 d-flex flex-column">
+                    <div class="position-relative" style="aspect-ratio: 1 / 1; background-color: #1c1c1e;">
+                        <img class="w-100 h-100" style="object-fit: cover;" alt="${escapeHtml(safeName)}">
+                    </div>
+                    <div class="p-3 d-flex flex-column gap-2 flex-grow-1">
+                        <div class="fw-bold text-white text-truncate" title="${escapeHtml(safeName)}">${escapeHtml(safeName)}</div>
+                        <div class="text-secondary small">${escapeHtml(formatDate(item.created_at))}</div>
+                        <a class="btn btn-outline-yellow btn-sm fw-semibold mt-auto d-flex align-items-center justify-content-center gap-2"
+                           download="truehair_${escapeHtml(filenameStem)}_${item.id}.webp">
+                            <i class="bi bi-download"></i> Download
+                        </a>
+                    </div>
+                </div>
+            `;
+            // Set blob URL via property to avoid string interpolation pitfalls.
+            col.querySelector("img").src = url;
+            col.querySelector("a.btn").href = url;
+            frag.appendChild(col);
+        }
+        gridEl.appendChild(frag);
+    }
+
+    (async () => {
+        try {
+            const items = await loadAllForCurrentUser();
+            render(items);
+        } catch (err) {
+            console.error("gallery load failed", err);
+            loadingEl.classList.add("d-none");
+            errorMsg.textContent = "We couldn't load your gallery. Try refreshing — if the problem persists, your browser may not support encrypted client-side storage.";
+            errorEl.classList.remove("d-none");
+        }
+    })();
+</script>
+{% endblock %}

--- a/app/templates/gallery.html
+++ b/app/templates/gallery.html
@@ -52,6 +52,25 @@
     <!-- Grid -->
     <div id="gallery-grid" class="row g-4 d-none"></div>
 
+    <!-- Shared fullscreen modal — same UX as result.html. JS sets the src on click. -->
+    <div class="modal fade" id="galleryImageModal" tabindex="-1" aria-labelledby="galleryImageModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-xl" style="max-width: 90vw;">
+            <div class="modal-content bg-transparent border-0" style="cursor: zoom-out;">
+                <h2 id="galleryImageModalLabel" class="visually-hidden">Fullscreen visualization</h2>
+                <div class="modal-header border-0 pb-0 position-absolute top-0 end-0 w-100 d-flex justify-content-end" style="z-index: 1055;">
+                    <button type="button" class="btn btn-dark border-0 m-3 d-flex align-items-center justify-content-center" data-bs-dismiss="modal" aria-label="Close"
+                        style="width: 44px; height: 44px; border-radius: 50%; background-color: rgba(42, 42, 45, 0.8); backdrop-filter: blur(4px); box-shadow: 0 4px 12px rgba(0,0,0,0.5); transition: all 0.2s ease; cursor: pointer;">
+                        <i class="bi bi-x-lg text-white"></i>
+                    </button>
+                </div>
+                <div class="modal-body text-center p-0 d-flex justify-content-center align-items-center">
+                    <img id="gallery-modal-image" src="" class="img-fluid rounded-4 shadow-lg" alt="Fullscreen visualization"
+                        style="max-height: 90vh; object-fit: contain; cursor: default;">
+                </div>
+            </div>
+        </div>
+    </div>
+
 </div>
 {% endblock %}
 
@@ -103,6 +122,23 @@
         });
     }
 
+    const modalEl = document.getElementById("galleryImageModal");
+    const modalImg = document.getElementById("gallery-modal-image");
+
+    function openFullscreen(url, alt) {
+        modalImg.src = url;
+        modalImg.alt = alt;
+        bootstrap.Modal.getOrCreateInstance(modalEl).show();
+    }
+
+    // Click anywhere on the modal backdrop area (but not on the image itself
+    // or the close button) dismisses — same UX as result.html.
+    modalEl.addEventListener("click", (e) => {
+        if (e.target.closest(".modal-content") && e.target.tagName !== "IMG" && !e.target.closest("button")) {
+            bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+        }
+    });
+
     function render(items) {
         loadingEl.classList.add("d-none");
 
@@ -125,6 +161,11 @@
                 <div class="bg-card rounded-4 border border-secondary border-opacity-25 overflow-hidden h-100 d-flex flex-column">
                     <div class="position-relative" style="aspect-ratio: 1 / 1; background-color: #1c1c1e;">
                         <img class="w-100 h-100" style="object-fit: cover;" alt="${escapeHtml(safeName)}">
+                        <button type="button" class="gallery-maximize-btn btn btn-dark border-secondary border-opacity-50 text-white position-absolute top-0 end-0 m-2 rounded-circle d-flex align-items-center justify-content-center"
+                            title="View fullscreen" aria-label="View fullscreen"
+                            style="width: 36px; height: 36px; z-index: 10; background-color: rgba(42, 42, 45, 0.8); backdrop-filter: blur(4px); transition: all 0.2s ease;">
+                            <i class="bi bi-arrows-fullscreen"></i>
+                        </button>
                     </div>
                     <div class="p-3 d-flex flex-column gap-2 flex-grow-1">
                         <div class="fw-bold text-white text-truncate" title="${escapeHtml(safeName)}">${escapeHtml(safeName)}</div>
@@ -139,6 +180,7 @@
             // Set blob URL via property to avoid string interpolation pitfalls.
             col.querySelector("img").src = url;
             col.querySelector("a.btn").href = url;
+            col.querySelector(".gallery-maximize-btn").addEventListener("click", () => openFullscreen(url, safeName));
             frag.appendChild(col);
         }
         gridEl.appendChild(frag);

--- a/app/templates/style_studio.html
+++ b/app/templates/style_studio.html
@@ -376,6 +376,22 @@
 </style>
 
 <script type="module">
+    import { persistGeneratedImage } from "{{ url_for('static', filename='js/gallery.js') }}";
+
+    // Persist a generated visualization to the encrypted IndexedDB gallery.
+    // Fire-and-forget: a persist failure must not block the user from seeing
+    // their result. Browsers without WebCrypto / IndexedDB just lose gallery
+    // access; the studio still works.
+    function persistToGallery(blob, { id, hairstyle_name }) {
+        persistGeneratedImage(blob, {
+            id,
+            hairstyle_name,
+            created_at: new Date().toISOString(),
+        }).catch((err) => {
+            console.warn("gallery: persist failed", err);
+        });
+    }
+
     // Module-level state
     const state = {
         photoFile: null,                // the File object
@@ -721,6 +737,14 @@
                 }
                 const blob = await res.blob();
                 const blobUrl = URL.createObjectURL(blob);
+                // Persist to gallery even if the user never picks this style —
+                // the GeneratedImage row was already created server-side, so
+                // the gallery is the only client-side counterpart.
+                const item = document.querySelector(`.hairstyle-item[data-id="${idStr}"]`);
+                persistToGallery(blob, {
+                    id: generatedImageId,
+                    hairstyle_name: item?.dataset?.name || "",
+                });
                 return { ok: true, blob, blobUrl, generatedImageId };
             } catch (e) {
                 // Surface pre-gen failures in DevTools so we have *some* signal
@@ -1039,7 +1063,16 @@
                 if (!Number.isFinite(parsedId)) {
                     throw new Error("Server did not return a valid image id");
                 }
-                blobUrl = URL.createObjectURL(await res.blob());
+                const liveBlob = await res.blob();
+                blobUrl = URL.createObjectURL(liveBlob);
+                // Persist live generations (catalog cache miss + reference path).
+                // Cached pre-gen blobs were already persisted in preGenerateOne.
+                persistToGallery(liveBlob, {
+                    id: parsedId,
+                    hairstyle_name: useReference
+                        ? "Custom reference"
+                        : (state.selectedHairstyleName || ""),
+                });
             }
 
             state.generatedImageId = parsedId;

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1440,3 +1440,51 @@ def test_api_generate_rejects_oversized_observation(auth_client, hairstyle):
         content_type="multipart/form-data",
     )
     assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /gallery + GET /api/me/storage-key (issue #106)
+# ---------------------------------------------------------------------------
+
+
+def test_gallery_unauthenticated_redirects_to_login(client):
+    response = client.get("/gallery")
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_gallery_authenticated_renders(auth_client):
+    response = auth_client.get("/gallery")
+    assert response.status_code == 200
+    # The page is a thin shell — gallery.js does the heavy lifting client-side.
+    assert b"gallery.js" in response.data
+
+
+def test_storage_key_unauthenticated_returns_401(client):
+    response = client.get("/api/me/storage-key")
+    assert response.status_code == 401
+
+
+def test_storage_key_returns_user_id_and_salt(auth_client, app):
+    from app.models import User
+
+    response = auth_client.get("/api/me/storage-key")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "user_id" in data and "salt" in data
+
+    with app.app_context():
+        user = db.session.get(User, data["user_id"])
+        assert user is not None
+        assert user.email == "user@example.com"
+        # Salt is server-issued and must match what the user was provisioned with.
+        assert data["salt"] == user.storage_salt
+        # Default salt is 32 random bytes hex-encoded → 64 chars.
+        assert len(data["salt"]) == 64
+
+
+def test_storage_key_is_stable_across_requests(auth_client):
+    """Salt persists across calls so encrypted blobs remain decryptable."""
+    first = auth_client.get("/api/me/storage-key").get_json()
+    second = auth_client.get("/api/me/storage-key").get_json()
+    assert first == second


### PR DESCRIPTION
## Summary

- Restores the user gallery feature deleted in #55 for the IRB no-storage rule. With login required and per-user `storage_salt` (added in #92), visualizations now live encrypted-on-device in IndexedDB.
- New `GET /api/me/storage-key` returns `{user_id, salt}` to the client; `gallery.js` derives an AES-GCM key via PBKDF2 over `${user_id}:${salt}`. Records are keyed by `[user_id, generated_image_id]` and indexed by `user_id`, so a different account on the same browser only ever sees their own ciphertext — the encryption layer is the second line of defense.
- Studio persists every successful generation (pre-gen #105 + live catalog + custom reference). One-time first-visit notice explains the on-device-only contract; dismissal is recorded in `localStorage`.

## Verification

In-browser checks against the dev server (signed Flask session for a real User row):

- [x] Encrypt/decrypt round-trip via `persistGeneratedImage` + `loadAllForCurrentUser`.
- [x] Records in IDB are AES-GCM ciphertext (12-byte IV, plaintext+16-byte auth tag) — not plaintext.
- [x] Multi-user isolation: injected a fake record with `user_id=999` directly into IDB; `loadAllForCurrentUser` for the signed-in user returned only their record.
- [x] Cross-reload persistence: 3 cards rendered after `location.reload()`, sorted newest-first, with proper `download` filenames.
- [x] First-visit tooltip: shown on first load, dismiss-once, hidden after reload.
- [x] Navbar Gallery link visible only when logged in; highlighted yellow on `/gallery`.
- [x] `/style-studio` still loads cleanly with the new `gallery.js` import.
- [x] `pytest` — all 117 tests pass (5 new for `/gallery` + `/api/me/storage-key`, 112 existing).

## Test plan

- [x] Generate a visualization in the studio (catalog path), refresh, visit `/gallery` — card appears with correct hairstyle name and download.
- [x] Generate via custom-reference upload — card appears as "Custom reference".
- [x] Trigger pre-gen (top recommendations) but click on a non-pre-genned style for the live path — both pre-gen and live result land in gallery.
- [x] Sign out, sign in as a different user on the same browser — gallery shows that user's records (or empty), never the previous user's.
- [x] DevTools → Application → Clear site data → reload `/gallery` — empty state and tooltip both reappear (clearing site data wipes both IDB and localStorage).

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an authenticated Gallery page to view and download your saved generated images.
  * Generated images from the style studio automatically persist to your encrypted personal gallery.
  * Gallery interface includes loading indicators, empty state guidance, and error handling for a smooth browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->