### PR TITLE
feat(studio): add 'Change photo' control to catalog phase

### DIFF
--- a/app/templates/style_studio.html
+++ b/app/templates/style_studio.html
@@ -121,6 +121,11 @@
     <section id="phase-catalog" class="phase" hidden>
         <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-end mb-4 gap-3">
             <div>
+                <button type="button" id="change-photo-btn"
+                    class="btn btn-link text-secondary p-0 mb-2 fw-semibold text-decoration-none"
+                    style="font-size: 0.9rem;">
+                    <i class="bi bi-arrow-left me-1"></i>Change photo
+                </button>
                 <h2 class="fw-bold mb-1">Pick a hairstyle</h2>
                 <p class="text-secondary mb-0">
                     Styles with a ✨ are AI-recommended based on your photo. Hover for why.
@@ -465,6 +470,14 @@
     const resultTitle = document.getElementById('result-title');
     const resultStyleName = document.getElementById('result-style-name');
     const resultStyleDesc = document.getElementById('result-style-desc');
+
+    const changePhotoBtn = document.getElementById('change-photo-btn');
+    // Snapshot the server-rendered grid order so a Change-photo reset can
+    // undo the hoisting that applyRecommendationHighlights() performs.
+    const hairstyleGrid = document.getElementById('hairstyle-grid');
+    const originalHairstyleOrder = Array.from(
+        hairstyleGrid.querySelectorAll('.hairstyle-item')
+    );
 
     // --- Phase Management ---
     function showPhase(name) {
@@ -1209,6 +1222,36 @@
         clearCatalogSelection();
         showPhase("catalog");
         window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+
+    // --- Phase 3 → 1 (Change Photo) ---
+    function clearRecommendationHighlights() {
+        document.querySelectorAll('.hairstyle-item').forEach(item => {
+            const card = item.querySelector('.style-card');
+            card.classList.remove('is-recommended');
+            item.querySelector('.rec-badge').classList.add('d-none');
+            delete item.dataset.reasoning;
+        });
+        // Restore the server-rendered order. appendChild moves nodes, so
+        // iterating in the original sequence reattaches them after the
+        // reference tile (which stays as the grid's first child).
+        originalHairstyleOrder.forEach(item => hairstyleGrid.appendChild(item));
+    }
+
+    changePhotoBtn.addEventListener('click', () => {
+        if (state.generatedImageBlobUrl) {
+            URL.revokeObjectURL(state.generatedImageBlobUrl);
+            state.generatedImageBlobUrl = null;
+        }
+        state.generatedImageId = null;
+        state.recommendations = null;
+        state.referenceFile = null;
+        state.aiPanelClickedId = null;
+        clearCatalogSelection();
+        clearRecommendationHighlights();
+        resetAIPanel();
+        clearPhoto();
+        showPhase('upload');
     });
     
     // --- Image Modal Click to Close ---


### PR DESCRIPTION
## Description

Adds a `← Change photo` back-link button to the catalog phase header on `/style-studio`, giving users an in-flow way to swap their selfie without falling back to the Style Studio nav link (which today is the only escape and triggers a full reload, discarding `state.photoFile`, recommendations, the observation, and the pre-gen blob cache).

## Related Issues

Closes #76

## Changes Made

- [x] New `#change-photo-btn` in the catalog header (above the "Pick a hairstyle" heading) — labeled `← Change photo`, styled as a secondary back-link.
- [x] Click handler resets all client state introduced by the catalog phase: `state.recommendations`, `state.selectedHairstyleId/Name/Desc`, `state.referenceFile`, `state.aiPanelClickedId`, `state.generatedImageBlobUrl` (revoked), `state.generatedImageId`. Then chains into the existing `clearPhoto()` so the upload phase fields (`photoFile`, `observation`, the file input, the preview/placeholder/observation-card UI, the pre-gen blob cache via `clearPreGenerated()`, the analyze-request id) all reset too.
- [x] New `clearRecommendationHighlights()` helper: removes `is-recommended` from every card, hides every `.rec-badge`, deletes `data-reasoning`, and restores the server-rendered grid order from a snapshot taken at script init (the reference-tile wrapper, the only non-`.hairstyle-item` child of `#hairstyle-grid`, stays as the first child).
- [x] AI reasoning panel reset to its empty state via the existing `resetAIPanel()`.
- [x] Calls `showPhase('upload')` so the user lands on a clean upload zone with no full reload.

No backend changes — re-uploading a photo replays the existing `/api/analyze-photo` → `/api/recommend` → `/api/generate` pipeline.

## Testing & Verification

Verified in the browser via the preview workflow on `flask-dev` (port 8000) at `/style-studio`:

1. Loaded the catalog phase, simulated `/api/recommend` results that hoisted styles 21, 16, and 9 to the top of the grid, applied a non-recommended selection on a 4th card, and showed the AI reasoning panel.
2. Clicked **Change photo**. Asserted post-state:
   - `phase: upload` (was `catalog`)
   - Grid order restored to monotonic 1→30, with the reference-tile wrapper still as the first child
   - 0 visible `.rec-badge`s (was 3), 0 `is-recommended` cards (was 3), 0 `data-reasoning` attrs (was 3)
   - 0 `is-selected` cards (was 1)
   - AI panel back to its empty state (✨ "Hover a recommended style…")
   - Upload zone reset: placeholder visible, preview container hidden, observation card hidden, file input value cleared
3. Ran the same cycle twice in a row — order restoration is idempotent.
4. Mobile viewport (375x812): button stacks above heading cleanly, no layout regressions.
5. No JS errors in the browser console at any point.
6. `pytest tests/test_routes.py -k studio` passes (3/3).

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works — no new automated tests added; this is a client-only state-reset on a Jinja template, exercised via the browser preview workflow per the issue's acceptance criteria. Happy to add a Selenium/Playwright test if the project wants UI-level coverage.
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings