### PR TITLE
ci: run migrations + seed scripts against Postgres on every PR

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,57 @@
+name: Run Migrations (Postgres)
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  migrations-postgres:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: truehair_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/truehair_ci
+      FLASK_APP: run.py
+      FLASK_SECRET_KEY: ci-not-a-secret
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Run migrations (upgrade head)
+        run: uv run flask db upgrade
+
+      - name: Validate latest migration's downgrade
+        run: |
+          uv run flask db downgrade -- -1
+          uv run flask db upgrade
+
+      - name: Run seed scripts
+        run: |
+          uv run python seed_hairstyles.py
+          uv run python seed_stylists.py


### PR DESCRIPTION
## Description

Adds a new GitHub Actions workflow that catches migration portability bugs pre-merge by running `flask db upgrade` against a real Postgres 17 service container (matching Heroku's prod 17.9). The existing `tests.yml` runs pytest against SQLite, which silently coerces booleans to integers and masked the `SET was_ai_recommended = 0` backfill bug in #125. This workflow is the long-term fix for that class of issue.

## Related Issues

Closes #128.

## Changes Made

- [x] New `.github/workflows/migrations.yml` with a `postgres:17` service container.
- [x] Runs `flask db upgrade` against the fresh Postgres.
- [x] Runs `flask db downgrade -- -1 && flask db upgrade` to validate the latest migration's downgrade path. Single-step (not full round-trip) because [`c3a1d2b4e5f6_irb_anonymous_identity.py`](migrations/versions/c3a1d2b4e5f6_irb_anonymous_identity.py) deliberately raises `NotImplementedError` to block reverse traversal past the PII drop.
- [x] Runs `seed_hairstyles.py` and `seed_stylists.py` to mirror the Heroku release-phase command in [Procfile](Procfile).

## Testing & Verification

- [x] YAML validated locally.
- [x] `flask db downgrade -- -1` syntax verified locally — Click requires the `--` separator since `-1` would otherwise be parsed as a flag.
- [x] Seed scripts confirmed self-contained (no network calls, no external dependencies).
- [ ] Full workflow run will be visible on this PR's checks tab — that's the real test.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (the workflow itself is the test; it runs on every subsequent PR)
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated database migration testing workflow to verify migration execution and rollback behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrueHair-AI/truehair-ai/pull/129)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->